### PR TITLE
Add composite unique index

### DIFF
--- a/models/category.js
+++ b/models/category.js
@@ -2,9 +2,13 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var categorySchema = mongoose.Schema({
-  name: { type: String, required: 'name cannot be blank', unique: true },
+  name: { type: String, required: 'name cannot be blank' },
   _site: { type: Schema.Types.ObjectId, ref: 'Site', required: '_site cannot be blank' }
 });
+
+// Adding unique to name above won't work as the name and _site combination need
+// to be unique.
+categorySchema.index({ name: 1, _site: 1 }, { unique: true });
 
 var Category = mongoose.model('Category', categorySchema);
 

--- a/models/company.js
+++ b/models/company.js
@@ -2,13 +2,17 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var companySchema = mongoose.Schema({
-  name: { type: String, required: 'name cannot be blank', unique: true },
+  name: { type: String, required: 'name cannot be blank' },
   url: { type: String, required: 'url cannot be blank' },
   twitter: String,
   _site: { type: Schema.Types.ObjectId, ref: 'Site', required: '_site cannot be blank' },
   _user: { type: Schema.Types.ObjectId, ref: 'User', required: '_user cannot be blank' },
   _jobs: [{ type: Schema.Types.ObjectId, ref: 'Job' }]
 });
+
+// Adding unique to name above won't work as the name and _site combination need
+// to be unique.
+companySchema.index({ name: 1, _site: 1 }, { unique: true });
 
 var Company = mongoose.model('Company', companySchema);
 

--- a/tests/models/category.js
+++ b/tests/models/category.js
@@ -17,11 +17,14 @@ describe('category', function () {
   });
 
   describe('saving', function () {
-    var site;
+    var site1;
+    var site2;
 
     before(function (done) {
-      site = new Site({hostname: 'www.tramcar.org', displayName: 'Tramcar', defaultSite: true});
-      site.save();
+      site1 = new Site({hostname: 'www.categorysite1.com', displayName: 'CategorySite1', defaultSite: true});
+      site1.save();
+      site2 = new Site({hostname: 'www.categorysite2.com', displayName: 'CategorySite2', defaultSite: false});
+      site2.save();
       done();
     });
 
@@ -31,18 +34,18 @@ describe('category', function () {
     });
 
     it('saves new record', function (done) {
-      var category = new Category({_site: site._id, name: 'test'});
+      var category = new Category({_site: site1._id, name: 'CategoryCategory1'});
       category.save(function (err) {
         should.not.exist(err);
         done();
       });
     });
 
-    it('does not save duplicate record', function (done) {
-      var category = new Category({_site: site._id, name: 'test'});
+    it('does not save duplicate name for same _site', function (done) {
+      var category = new Category({_site: site1._id, name: 'CategoryCategory1'});
       category.save(function (err) {
         if (err) throw err;
-        var duplicate = new Category({_site: site._id, name: 'test'});
+        var duplicate = new Category({_site: site1._id, name: 'CategoryCategory1'});
         duplicate.save(function (err) {
           should.exist(err);
           done();
@@ -50,8 +53,20 @@ describe('category', function () {
       });
     });
 
+    it('does save duplicate name for different _site', function (done) {
+      var category = new Category({_site: site1._id, name: 'CategoryCategory1'});
+      category.save(function (err) {
+        if (err) throw err;
+        var duplicate = new Category({_site: site2._id, name: 'CategoryCategory1'});
+        duplicate.save(function (err) {
+          should.not.exist(err);
+          done();
+        });
+      });
+    });
+
     it('does not save without a name', function (done) {
-      var category = new Category({_site: site._id});
+      var category = new Category({_site: site1._id});
       category.save(function (err) {
         should.exist(err);
         err.errors.name.message.should.equal('name cannot be blank');
@@ -60,7 +75,7 @@ describe('category', function () {
     });
 
     it('does not save without a _site reference', function (done) {
-      var category = new Category({name: 'test'});
+      var category = new Category({name: 'CategoryCategory1'});
       category.save(function (err) {
         should.exist(err);
         err.errors._site.message.should.equal('_site cannot be blank');

--- a/tests/models/company.js
+++ b/tests/models/company.js
@@ -19,13 +19,16 @@ describe('company', function () {
   });
 
   describe('saving', function () {
-    var site;
+    var site1;
+    var site2;
     var user;
 
     before(function (done) {
-      site = new Site({hostname: 'www.tramcar.org', displayName: 'Tramcar', defaultSite: true});
-      site.save();
-      user = new User({uid: 'b832727d-b682-4911-87fb-5e0a0f895406', name: 'Abc Def', _site: site.id});
+      site1 = new Site({hostname: 'www.companysite1.com', displayName: 'CompanySite1', defaultSite: true});
+      site1.save();
+      site2 = new Site({hostname: 'www.companysite2.com', displayName: 'CompanySite2', defaultSite: false});
+      site2.save();
+      user = new User({uid: 'b832727d-b682-4911-87fb-5e0a0f895406', name: 'Abc Def', _site: site1.id});
       user.save();
       done();
     });
@@ -36,18 +39,18 @@ describe('company', function () {
     });
 
     it('saves new record', function (done) {
-      var company = new Company({_site: site._id, _user: user.id, name: 'Tramcar', url: 'https://www.tramcar.org', twitter: 'tramcarjs'});
+      var company = new Company({_site: site1._id, _user: user.id, name: 'CompanyCompany1', url: 'https://companycompany1.com', twitter: 'companycompany1'});
       company.save(function (err) {
         should.not.exist(err);
         done();
       });
     });
 
-    it('does not save duplicate record', function (done) {
-      var company = new Company({_site: site._id, _user: user.id, name: 'Tramcar', url: 'https://www.tramcar.org'});
+    it('does not save duplicate name for same _site', function (done) {
+      var company = new Company({_site: site1._id, _user: user.id, name: 'CompanyCompany1', url: 'https://companycompany1.com'});
       company.save(function (err) {
         if (err) throw err;
-        var duplicate = new Company({_site: site._id, _user: user.id, name: 'Tramcar', url: 'https://www.tramcar.org'});
+        var duplicate = new Company({_site: site1._id, _user: user.id, name: 'CompanyCompany1', url: 'https://companycompany1.com'});
         duplicate.save(function (err) {
           should.exist(err);
           done();
@@ -55,8 +58,20 @@ describe('company', function () {
       });
     });
 
+    it('does save duplicate name for different _site', function (done) {
+      var company = new Company({_site: site1._id, _user: user.id, name: 'CompanyCompany1', url: 'https://companycompany1.com'});
+      company.save(function (err) {
+        if (err) throw err;
+        var duplicate = new Company({_site: site2._id, _user: user.id, name: 'CompanyCompany1', url: 'https://companycompany1.com'});
+        duplicate.save(function (err) {
+          should.not.exist(err);
+          done();
+        });
+      });
+    });
+
     it('does not save without a name', function (done) {
-      var company = new Company({_site: site._id, _user: user.id, url: 'https://www.tramcar.org'});
+      var company = new Company({_site: site1._id, _user: user.id, url: 'https://companycompany1.com'});
       company.save(function (err) {
         should.exist(err);
         err.errors.name.message.should.equal('name cannot be blank');
@@ -65,7 +80,7 @@ describe('company', function () {
     });
 
     it('does not save without a URL', function (done) {
-      var company = new Company({_site: site._id, _user: user.id, name: 'Tramcar'});
+      var company = new Company({_site: site1._id, _user: user.id, name: 'CompanyCompany1'});
       company.save(function (err) {
         should.exist(err);
         err.errors.url.message.should.equal('url cannot be blank');
@@ -74,7 +89,7 @@ describe('company', function () {
     });
 
     it('does not save without a _site reference', function (done) {
-      var company = new Company({_user: user.id, name: 'Tramcar', url: 'https://www.tramcar.org'});
+      var company = new Company({_user: user.id, name: 'CompanyCompany1', url: 'https://companycompany1.com'});
       company.save(function (err) {
         should.exist(err);
         err.errors._site.message.should.equal('_site cannot be blank');
@@ -83,7 +98,7 @@ describe('company', function () {
     });
 
     it('does not save without a _user reference', function (done) {
-      var company = new Company({_site: site._id, name: 'Tramcar', url: 'https://www.tramcar.org'});
+      var company = new Company({_site: site1._id, name: 'Tramcar', url: 'https://companycompany1.com'});
       company.save(function (err) {
         should.exist(err);
         err.errors._user.message.should.equal('_user cannot be blank');

--- a/tests/models/country.js
+++ b/tests/models/country.js
@@ -21,7 +21,7 @@ describe('country', function () {
     });
 
     it('saves new record', function (done) {
-      var country = new Country({name: 'Canada'});
+      var country = new Country({name: 'CountryCountry1'});
       country.save(function (err) {
         should.not.exist(err);
         done();
@@ -29,10 +29,10 @@ describe('country', function () {
     });
 
     it('does not save duplicate record', function (done) {
-      var country = new Country({name: 'Canada'});
+      var country = new Country({name: 'CountryCountry1'});
       country.save(function (err) {
         if (err) throw err;
-        var duplicate = new Country({name: 'Canada'});
+        var duplicate = new Country({name: 'CountryCountry1'});
         duplicate.save(function (err) {
           should.exist(err);
           done();

--- a/tests/models/job.js
+++ b/tests/models/job.js
@@ -33,18 +33,18 @@ describe('job', function () {
     var _job;
 
     before(function (done) {
-      site = new Site({hostname: 'www.tramcar.org', displayName: 'Tramcar', defaultSite: true});
+      site = new Site({hostname: 'www.jobsite1.com', displayName: 'JobSite1', defaultSite: true});
       site.save();
       user = new User({uid: 'b832727d-b682-4911-87fb-5e0a0f895406', name: 'Abc Def', _site: site.id});
       user.save();
-      country = new Country({name: 'Canada'});
+      country = new Country({name: 'JobCountry1'});
       country.save();
-      category = new Category({name: 'Software Development', _site: site.id});
+      category = new Category({name: 'JobCategory1', _site: site.id});
       category.save();
-      company = new Company({name: 'WFH.io', url: 'https://www.wfh.io', twitter: '@WFHio'});
+      company = new Company({name: 'JobCompany1', url: 'https://www.jobcompany1.com', twitter: '@jobcompany1'});
       company.save();
 
-      _job = new Job({title: 'Software Developer',
+      _job = new Job({title: 'JobCategory1',
                      description: 'Test description here',
                      application_info: 'https://www.wfh.io/dummy/job',
                      email: 'doesnotexist@wfh.io',

--- a/tests/models/site.js
+++ b/tests/models/site.js
@@ -21,7 +21,7 @@ describe('site', function () {
     });
 
     it('saves new record', function (done) {
-      var site = new Site({hostname: 'www.tramcar.org', displayName: 'Tramcar', defaultSite: true});
+      var site = new Site({hostname: 'www.sitesite1.com', displayName: 'SiteSite1', defaultSite: true});
       site.save(function (err) {
         should.not.exist(err);
         done();
@@ -29,10 +29,10 @@ describe('site', function () {
     });
 
     it('does not save duplicate record', function (done) {
-      var site = new Site({hostname: 'www.tramcar.org', displayName: 'Tramcar', defaultSite: true});
+      var site = new Site({hostname: 'www.sitesite1.com', displayName: 'SiteSite1', defaultSite: true});
       site.save(function (err) {
         if (err) throw err;
-        var duplicate = new Site({hostname: 'www.tramcar.org', displayName: 'Tramcar', defaultSite: true});
+        var duplicate = new Site({hostname: 'www.sitesite1.com', displayName: 'SiteSite1', defaultSite: true});
         duplicate.save(function (err) {
           should.exist(err);
           done();
@@ -41,7 +41,7 @@ describe('site', function () {
     });
 
     it('does not save without a hostname', function (done) {
-      var site = new Site({displayName: 'Tramcar', defaultSite: true});
+      var site = new Site({displayName: 'SiteSite1.com', defaultSite: true});
       site.save(function (err) {
         should.exist(err);
         err.errors.hostname.message.should.equal('hostname cannot be blank');
@@ -50,7 +50,7 @@ describe('site', function () {
     });
 
     it('does not save without a displayName', function (done) {
-      var site = new Site({hostname: 'www.tramcar.org', defaultSite: true});
+      var site = new Site({hostname: 'www.sitesite1.com', defaultSite: true});
       site.save(function (err) {
         should.exist(err);
         err.errors.displayName.message.should.equal('displayName cannot be blank');


### PR DESCRIPTION
Currently, we have a unique index on name in category and company
models.  This works fine except when you have mutliple sites trying to
save the same companies or categories.  This commit updates both models
to use a composite unique index on name and _site.

Additionally, we update all the model tests to use unique names to
avoid errors resulting from these tests running in parallel.  This
does not resolve the issue 100% but does seem to reduce errors
significantly.

Closes #10