### PR TITLE
Do not reference Country model in Job

### DIFF
--- a/models/job.js
+++ b/models/job.js
@@ -10,11 +10,12 @@ var jobSchema = mongoose.Schema(
     email: { type: String, required: 'email cannot be blank' },
     paid_at: { type: Date },
     expired_at: { type: Date },
+    country: { type: String },
     _site: { type: Schema.Types.ObjectId, ref: 'Site', required: '_site cannot be blank' },
     _user: { type: Schema.Types.ObjectId, ref: 'User', required: '_user cannot be blank' },
     _category: { type: Schema.Types.ObjectId, ref: 'Category', required: '_category cannot be blank' },
-    _company: { type: Schema.Types.ObjectId, ref: 'Company', required: '_company cannot be blank' },
-    _country: { type: Schema.Types.ObjectId, ref: 'Country', required: '_country cannot be blank' }
+    _company: { type: Schema.Types.ObjectId, ref: 'Company', required: '_company cannot be blank' }
+
   },
   {
     timestamps: true

--- a/tests/models/job.js
+++ b/tests/models/job.js
@@ -48,11 +48,11 @@ describe('job', function () {
                      description: 'Test description here',
                      application_info: 'https://www.wfh.io/dummy/job',
                      email: 'doesnotexist@wfh.io',
+                     country: country.name,
                      _site: site.id,
                      _user: user.id,
                      _category: category.id,
-                     _company: company.id,
-                     _country: country.id});
+                     _company: company.id});
 
       done();
     });
@@ -159,13 +159,12 @@ describe('job', function () {
       });
     });
 
-    it('does not save without a _country reference', function (done) {
+    it('does save without a country reference', function (done) {
       var clone = JSON.parse(JSON.stringify(_job));
-      delete clone._country;
+      delete clone.country;
       var job = new Job(clone);
       job.save(function (err) {
-        should.exist(err);
-        err.errors._country.message.should.equal('_country cannot be blank');
+        should.not.exist(err);
         done();
       });
     });

--- a/views/jobs/edit.jade
+++ b/views/jobs/edit.jade
@@ -44,15 +44,15 @@ block content
       label(for='application_info') Application Info
       textarea(name="application_info", rows='2', class='form-control')= job.application_info
     div(class='form-group')
-      label(for='_country') Country
-      select(name="_country", class='form-control')
+      label(for='country') Country
+      select(name="country", class='form-control')
         option(value="" selected)
         each country in countries
           //- TODO: find a better way to do this
-          if job._country == country.id
-            option(value="#{country.id}" selected)= country.name
+          if job.country == country.name
+            option(value="#{country.name}" selected)= country.name
           else
-            option(value="#{country.id}")= country.name
+            option(value="#{country.name}")= country.name
     div(class='form-group')
       label(for='location') Location
       textarea(name="location", class='form-control')= job.location

--- a/views/jobs/new.jade
+++ b/views/jobs/new.jade
@@ -44,15 +44,15 @@ block content
       label(for='application_info') Application Info
       textarea(name="application_info", rows='2', class='form-control') #{job.application_info ? job.application_info : ''}
     div(class='form-group')
-      label(for='_country') Country
-      select(name="_country", class='form-control')
+      label(for='country') Country
+      select(name="country", class='form-control')
         option(value="" selected)
         each country in countries
           //- TODO: find a better way to do this
-          if job._country && job._country == country.id
-            option(value="#{country.id}" selected)= country.name
+          if job.country && job.country == country.name
+            option(value="#{country.name}" selected)= country.name
           else
-            option(value="#{country.id}")= country.name
+            option(value="#{country.name}")= country.name
     div(class='form-group')
       label(for='location') Location
       textarea(name="location", class='form-control') #{job.location ? job.location : ''}

--- a/views/jobs/show.jade
+++ b/views/jobs/show.jade
@@ -48,10 +48,10 @@ block content
       h4
         mark Application Info
       p(style='white-space:pre-wrap;')!= sanitizeHtml(converter.makeHtml(job.application_info))
-      if job._country
+      if job.country
         h4
           mark Country
-        p(style='white-space:pre-wrap;')= job._country.name
+        p(style='white-space:pre-wrap;')= job.country
       h4
         mark Location
       p(style='white-space:pre-wrap;')= job.location


### PR DESCRIPTION
As it is unclear how to make a reference field in a model optional, we
have removed the _country reference in Job and now just save the
country's name instead.  While it is nice having the reference to
Country, the Country table really should be static and having the
country name embedded in the job means we have to do one less query
when the job is being shown.

Closes #14