### PR TITLE
Define default ordering

### DIFF
--- a/job_board/models.py
+++ b/job_board/models.py
@@ -16,6 +16,7 @@ class Category(models.Model):
     class Meta:
         verbose_name_plural = "categories"
         unique_together = ("name", "site")
+        ordering = ['name']
 
     def __str__(self):
         return self.name
@@ -30,6 +31,7 @@ class Country(models.Model):
 
     class Meta:
         verbose_name_plural = "countries"
+        ordering = ['name']
 
     def __str__(self):
         return self.name
@@ -48,6 +50,7 @@ class Company(models.Model):
     class Meta:
         verbose_name_plural = "companies"
         unique_together = ("name", "site")
+        ordering = ['name']
 
     def __str__(self):
         return self.name

--- a/job_board/views.py
+++ b/job_board/views.py
@@ -99,7 +99,7 @@ def jobs_activate(request, job_id):
 
 
 def categories_index(request):
-    categories = Category.on_site.all().order_by('name')
+    categories = Category.on_site.all()
     context = {'categories': categories }
     return render(request, 'job_board/categories_index.html', context)
 
@@ -111,7 +111,7 @@ def categories_show(request, category_id):
 
 
 def companies_index(request):
-    companies = Company.on_site.all().order_by('name')
+    companies = Company.on_site.all()
     context = {'companies': companies }
     return render(request, 'job_board/companies_index.html', context)
 


### PR DESCRIPTION
The category and company models should always be ordered by name.  This
commit updates models.py to set the default ordering and removes the
explicit ordering on the queries in views.py.
