### PR TITLE
404 when user not owner and job unpaid

### DIFF
--- a/job_board/templates/job_board/jobs_mine.html
+++ b/job_board/templates/job_board/jobs_mine.html
@@ -12,6 +12,7 @@
       <th>Company</th>
       <th>Country</th>
       <th>Category</th>
+      <th>Expired</th>
     </tr>
   </thead>
   {% for job in jobs %}
@@ -21,6 +22,15 @@
     <td><a href="{% url 'companies_show' job.company.id %}">{{ job.company.name }}</a></td>
     <td>{{ job.format_country }}</td>
     <td><a href="{% url 'categories_show' job.category.id %}">{{ job.category.name }}</a></td>
+    <td>
+      {% if not job.paid_at and not job.expired_at %}
+      <span class="label label-warning %>">Unpaid</span>
+      {% elif job.paid_at and not job.expired_at %}
+      <span class="label label-success %>">Paid</span>
+      {% elif job.paid_at and job.expired_at %}
+      <span class="label label-warning %>">Expired</span>
+      {% endif %}
+    </td>
   </tr>
   {% endfor %}
 </table>

--- a/job_board/templates/job_board/jobs_show.html
+++ b/job_board/templates/job_board/jobs_show.html
@@ -49,7 +49,7 @@
     <h4><mark>Category</mark></h4>
     <p><a href="{% url 'categories_show' job.category.id %}">{{ job.category }}</a></p>
     <h4><mark>Post Date</mark></h4>
-    <p>{{ job.paid_at|date:'Y-m-d H:i' }}</p>
+    <p>{{ post_date|date:'Y-m-d H:i' }}</p>
     <h4><mark>Description</mark></h4>
     <p>{{ job.description_md | safe }}</p>
     <h4><mark>Application Info</mark></h4>


### PR DESCRIPTION
This commit updates views.py to 404 when the browsing user is not the
job owner and the job has not been paid for.  We do not want these jobs
to be visible on the site when they haven't been paid for.

Additionally, we:
- update jobs_mine.html template to show the status of each job
- change the ordering of jobs in jobs_mine.html by updating the sort
  order in views.py
- update jobs_show.html to show a post date of created_at when the
  browsing user is the owner and the job is unpaid for
- remove some debugging from views.py
