### PR TITLE
Add custom command to expire jobs

### DIFF
--- a/job_board/commands/expire.py
+++ b/job_board/commands/expire.py
@@ -1,0 +1,18 @@
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+from job_board.models import Job, Site
+
+class Command(BaseCommand):
+    help = 'Expire all jobs older than 30 days'
+
+    def handle(self, *args, **options):
+        days_ago = timezone.now() - timedelta(days=30)
+        jobs = Job.objects.filter(paid_at__lt=days_ago, expired_at__isnull=True)
+        for job in jobs:
+            job.expired_at = timezone.now()
+            job.save()
+
+        if jobs:
+            self.stdout.write(self.style.SUCCESS('Successfully expired %s jobs' % len(jobs)))

--- a/job_board/models.py
+++ b/job_board/models.py
@@ -73,6 +73,9 @@ class Job(models.Model):
     paid_at = models.DateTimeField(null=True)
     expired_at = models.DateTimeField(null=True)
     site = models.ForeignKey(Site, on_delete=models.CASCADE)
+    # When using CurrentSiteManager, we do not have access to Job.objects,
+    # which we need when we want to expire all jobs irrespective of site
+    objects = models.Manager()
     on_site = CurrentSiteManager()
     user = models.ForeignKey(User, on_delete=models.CASCADE)
 


### PR DESCRIPTION
This commit adds a custom command to manage.py to expire jobs.
Currently, all jobs will expire after 30 days (when this is run), but
a future edit should allow the days to be configurable by site.
