### PR TITLE
Add expire method to Job model

### DIFF
--- a/job_board/commands/expire.py
+++ b/job_board/commands/expire.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 
 from django.core.management.base import BaseCommand, CommandError
-from django.utils import timezone
+
 from job_board.models import Job, Site
 
 class Command(BaseCommand):
@@ -11,8 +11,7 @@ class Command(BaseCommand):
         days_ago = timezone.now() - timedelta(days=30)
         jobs = Job.objects.filter(paid_at__lt=days_ago, expired_at__isnull=True)
         for job in jobs:
-            job.expired_at = timezone.now()
-            job.save()
+            job.expire()
 
         if jobs:
             self.stdout.write(self.style.SUCCESS('Successfully expired %s jobs' % len(jobs)))

--- a/job_board/models.py
+++ b/job_board/models.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
 from django.contrib.sites.managers import CurrentSiteManager
+from django.utils import timezone
 from django.utils.encoding import python_2_unicode_compatible
 
 
@@ -78,6 +79,10 @@ class Job(models.Model):
     objects = models.Manager()
     on_site = CurrentSiteManager()
     user = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    def expire(self):
+        self.expired_at = timezone.now()
+        self.save()
 
     def format_country(self):
         if self.country:

--- a/job_board/tests.py
+++ b/job_board/tests.py
@@ -4,6 +4,21 @@ from django.test import TestCase
 from .models import Job
 
 
+class JobMethodTests(TestCase):
+    def setUp(self):
+        # Note that we're assigning non-existent values for country,
+        # category, etc.
+        job = Job(title='Software Developer', country_id=1, category_id=1,
+                  company_id=1, site_id=1, user_id=1)
+        job.paid_at = job.created_at
+        job.save()
+
+    def test_expire(self):
+        job = Job.objects.get(title='Software Developer')
+        job.expire()
+        self.assertIsNotNone(job.expired_at)
+
+
 class JobViewTests(TestCase):
 
     def test_index_view(self):

--- a/job_board/views.py
+++ b/job_board/views.py
@@ -104,8 +104,7 @@ def jobs_expire(request, job_id):
     if request.user.id != job.user.id:
         return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
 
-    job.expired_at = timezone.now()
-    job.save()
+    job.expire()
     return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
 
 


### PR DESCRIPTION
This commit adds an expire method to the Job model so that we can
remove some duplicate code.  We also add a test to ensure that
expiring a job sets the attribute to a non None value.
