### PR TITLE
Add activate method to job and expand expire method

### DIFF
--- a/job_board/models.py
+++ b/job_board/models.py
@@ -80,9 +80,21 @@ class Job(models.Model):
     on_site = CurrentSiteManager()
     user = models.ForeignKey(User, on_delete=models.CASCADE)
 
+    def activate(self):
+        if self.paid_at is None:
+            self.paid_at = timezone.now()
+            self.save()
+            return True
+        else:
+            return False
+
     def expire(self):
-        self.expired_at = timezone.now()
-        self.save()
+        if self.paid_at is not None and self.expired_at is None:
+            self.expired_at = timezone.now()
+            self.save()
+            return True
+        else:
+            return False
 
     def format_country(self):
         if self.country:

--- a/job_board/tests.py
+++ b/job_board/tests.py
@@ -13,11 +13,36 @@ class JobMethodTests(TestCase):
         job.paid_at = job.created_at
         job.save()
 
-    def test_expire(self):
+    def test_activate_on_unactivated_job(self):
         job = Job.objects.get(title='Software Developer')
-        job.expire()
+        self.assertTrue(job.activate())
+        self.assertIsNotNone(job.paid_at)
+
+    def test_activate_on_already_activated_job(self):
+        job = Job.objects.get(title='Software Developer')
+        job.activate()
+        paid_at = job.paid_at
+        self.assertFalse(job.activate())
+        self.assertEqual(paid_at, job.paid_at)
+
+    def test_expire_on_unexpired_job(self):
+        job = Job.objects.get(title='Software Developer')
+        job.activate()
+        self.assertTrue(job.expire())
         self.assertIsNotNone(job.expired_at)
 
+    def test_expire_on_already_expired_job(self):
+        job = Job.objects.get(title='Software Developer')
+        job.activate()
+        job.expire()
+        expired_at = job.expired_at
+        self.assertFalse(job.expire())
+        self.assertEqual(expired_at, job.expired_at)
+
+    def test_expire_on_unactivated_job(self):
+        job = Job.objects.get(title='Software Developer')
+        self.assertFalse(job.expire())
+        self.assertIsNone(job.expired_at)
 
 class JobViewTests(TestCase):
 

--- a/job_board/views.py
+++ b/job_board/views.py
@@ -5,7 +5,6 @@ from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import get_list_or_404, get_object_or_404, render
-from django.utils import timezone
 
 from .forms import CompanyForm, JobForm
 from .models import Category, Company, Job
@@ -92,8 +91,7 @@ def jobs_edit(request, job_id):
 @staff_member_required(login_url='/login/')
 def jobs_activate(request, job_id):
     job = get_object_or_404(Job, pk=job_id, site_id=request.site)
-    job.paid_at = timezone.now()
-    job.save()
+    job.activate()
     return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
 
 
@@ -105,14 +103,6 @@ def jobs_expire(request, job_id):
         return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
 
     job.expire()
-    return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
-
-
-@staff_member_required(login_url='/login/')
-def jobs_activate(request, job_id):
-    job = get_object_or_404(Job, pk=job_id, site_id=request.site)
-    job.paid_at = timezone.now()
-    job.save()
     return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
 
 


### PR DESCRIPTION
This commit adds an activate method to the job model and updates the
expire method so that already expired jobs cannot be expired again.
We also remove a duplicate jobs_activate method from
job_board/views.py.

Lastly, this commit adds a number of new tests to properly test the
activate and expire methods.
