### PR TITLE
Update companies_index view

### DIFF
--- a/job_board/models.py
+++ b/job_board/models.py
@@ -45,6 +45,9 @@ class Company(models.Model):
     twitter = models.CharField(max_length=20)
     country = models.ForeignKey(Country, blank=True, null=True)
     site = models.ForeignKey(Site, on_delete=models.CASCADE)
+    # When using CurrentSiteManager, we do not have access to Company.objects,
+    # which we need when we want to expire all jobs irrespective of site
+    objects = models.Manager()
     on_site = CurrentSiteManager()
     user = models.ForeignKey(User, on_delete=models.CASCADE)
 
@@ -55,6 +58,10 @@ class Company(models.Model):
 
     def __str__(self):
         return self.name
+
+    def active_jobs(self):
+        return self.job_set.filter(paid_at__isnull=False,
+                                   expired_at__isnull=True)
 
     def paid_jobs(self):
         return self.job_set.filter(paid_at__isnull=False)

--- a/job_board/templates/job_board/companies_index.html
+++ b/job_board/templates/job_board/companies_index.html
@@ -8,15 +8,19 @@
   <thead>
     <tr>
       <th>Name</th>
+      <th>URL</th>
       <th>Twitter</th>
-      <th>Job Count</th>
+      <th>Total Jobs</th>
+      <th>Active Jobs</th>
     </tr>
   </thead>
   {% for company in companies %}
   <tr>
     <td><a href="{% url 'companies_show' company.id %}">{{ company.name }}</a></td>
+    <td><a href="{{ company.url }}">{{ company.url }}</a></td>
     <td><a href="https://www.twitter.com/{{ company.twitter }}">{{ company.twitter }}</a></td>
     <td>{{ company.paid_jobs.count }}</td>
+    <td>{{ company.active_jobs.count }}</td>
   </tr>
   {% endfor %}
 </table>

--- a/job_board/tests.py
+++ b/job_board/tests.py
@@ -1,7 +1,35 @@
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
-from .models import Job
+from .models import Company, Job
+
+
+class CompanyMethodTests(TestCase):
+    def setUp(self):
+        # Note that we're assigning non-existent values for country,
+        # category, etc.
+        company = Company(name='Tramcar', site_id=1, user_id=1)
+        company.save()
+
+    def test_active_jobs(self):
+        company = Company.objects.get(name='Tramcar')
+        job = Job(title='Software Developer', country_id=1,
+                  category_id=1, company_id=company.id, site_id=1,
+                  user_id=1)
+        job.save()
+        self.assertEqual(len(company.active_jobs()), 0)
+        job.activate()
+        self.assertEqual(len(company.active_jobs()), 1)
+
+    def test_paid_jobs(self):
+        company = Company.objects.get(name='Tramcar')
+        job = Job(title='Software Developer', country_id=1,
+                         category_id=1, company_id=company.id, site_id=1,
+                         user_id=1)
+        job.save()
+        self.assertEqual(len(company.paid_jobs()), 0)
+        job.activate()
+        self.assertEqual(len(company.paid_jobs()), 1)
 
 
 class JobMethodTests(TestCase):


### PR DESCRIPTION
This commit updates the companies_index view to include:
1. Company's URL
2. Company's # of active jobs

Additionally, we add a new method to company model to return # of active
jobs, and add some tests to test the active_jobs and paid_jobs methods.
