### PR TITLE
Only show active jobs when browsing category

### DIFF
--- a/job_board/tests.py
+++ b/job_board/tests.py
@@ -111,7 +111,7 @@ class CategoryViewTests(TestCase):
 
     def test_show_view(self):
         response = self.client.get(reverse('categories_show', args=(1,)))
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
 
 
 class CompanyViewTests(TestCase):

--- a/job_board/views.py
+++ b/job_board/views.py
@@ -4,7 +4,7 @@ from django.contrib.auth.forms import UserCreationForm
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect
-from django.shortcuts import get_list_or_404, get_object_or_404, render
+from django.shortcuts import get_object_or_404, render
 
 from .forms import CompanyForm, JobForm
 from .models import Category, Company, Job
@@ -113,7 +113,10 @@ def categories_index(request):
 
 
 def categories_show(request, category_id):
-    jobs = get_list_or_404(Job, category_id=category_id, site_id=request.site)
+    jobs = Job.on_site.filter(category_id=category_id) \
+                      .filter(paid_at__isnull=False) \
+                      .filter(expired_at__isnull=True) \
+                      .order_by('paid_at')
     context = {'jobs': jobs}
     return render(request, 'job_board/jobs_index.html', context)
 


### PR DESCRIPTION
Currently, all jobs (include those expired) are displayed when view
a category.  This commit updates the view to only select those that
are active.

Note that switch from using get_list_or_404 here, which means we no
longer get a 404 and requires a test update.  It doesn't seem logical
to return a 404 on the categories_show view when no jobs in that
category exist as that will wreak havoc w/ search engines, etc.
