### PR TITLE
[WIP] Remove usage of CurrentSiteManager

### DIFF
--- a/job_board/context_processors.py
+++ b/job_board/context_processors.py
@@ -1,0 +1,4 @@
+from django.contrib.sites.shortcuts import get_current_site
+
+def get_site(request):
+    return {'current_site': get_current_site(request)}

--- a/job_board/models.py
+++ b/job_board/models.py
@@ -4,7 +4,6 @@ from django.dispatch import receiver
 from django.db import models
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
-from django.contrib.sites.managers import CurrentSiteManager
 from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.utils import timezone
@@ -28,7 +27,6 @@ def generate_site_config(sender, **kwargs):
 class Category(models.Model):
     name = models.CharField(max_length=30)
     site = models.ForeignKey(Site, on_delete=models.CASCADE)
-    on_site = CurrentSiteManager()
 
     class Meta:
         verbose_name_plural = "categories"
@@ -70,10 +68,6 @@ class Company(models.Model):
                   help_text="Please leave empty if 100% virtual"
               )
     site = models.ForeignKey(Site, on_delete=models.CASCADE)
-    # When using CurrentSiteManager, we do not have access to Company.objects,
-    # which we need when we want to expire all jobs irrespective of site
-    objects = models.Manager()
-    on_site = CurrentSiteManager()
     user = models.ForeignKey(User, on_delete=models.CASCADE)
 
     class Meta:
@@ -126,10 +120,6 @@ class Job(models.Model):
     paid_at = models.DateTimeField(null=True)
     expired_at = models.DateTimeField(null=True)
     site = models.ForeignKey(Site, on_delete=models.CASCADE)
-    # When using CurrentSiteManager, we do not have access to Job.objects,
-    # which we need when we want to expire all jobs irrespective of site
-    objects = models.Manager()
-    on_site = CurrentSiteManager()
     user = models.ForeignKey(User, on_delete=models.CASCADE)
 
     def activate(self):
@@ -177,8 +167,6 @@ class SiteConfig(models.Model):
     #       suitable default when we create the SiteConfig instance
     admin_email = models.EmailField(default='admin@site')
     site = models.ForeignKey(Site, on_delete=models.CASCADE)
-    objects = models.Manager()
-    on_site = CurrentSiteManager()
 
     def __str__(self):
         return self.site.name

--- a/job_board/templates/job_board/base.html
+++ b/job_board/templates/job_board/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>{{ title|default:request.site.name}}</title>
+    <title>{{ title|default:current_site.name}}</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7" crossorigin="anonymous">
     <script src="https://code.jquery.com/jquery-1.12.0.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
@@ -10,7 +10,7 @@
     <nav class="navbar navbar-default">
       <div class="container-fluid">
         <div class="navbar-header">
-          <button type="button" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false" class="navbar-toggle collapsed"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button><a href="/" class="navbar-brand">{{ request.site.name }}</a>
+          <button type="button" data-toggle="collapse" data-target="#bs-example-navbar-collapse-1" aria-expanded="false" class="navbar-toggle collapsed"><span class="sr-only">Toggle navigation</span><span class="icon-bar"></span><span class="icon-bar"></span><span class="icon-bar"></span></button><a href="/" class="navbar-brand">{{ current_site.name }}</a>
         </div>
         <div id="bs-example-navbar-collapse-1" class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
@@ -35,7 +35,7 @@
       </div>
     </nav>
     <div class="container">
-      <h1>{{ title|default:request.site.name }}</h1>
+      <h1>{{ title|default:current_site.name }}</h1>
       {% block content %}{% endblock %}
       <p class="text-center">
         <small><a href="https://github.com/wfhio/tramcar">Powered by Tramcar</a></small>

--- a/job_board/templates/job_board/markdown.html
+++ b/job_board/templates/job_board/markdown.html
@@ -8,13 +8,13 @@
       <td>__Strong Emphasis__</td><td><strong>Strong Emphasis</strong></td>
     </tr>
     <tr>
-      <td>&#60;http://www.{{ request.site.domain }}&#62;</td><td><a href="http://www.{{ request.site.domain }}">http://www.{{ request.site.domain }}</a></td>
+      <td>&#60;http://www.{{ current_site.domain }}&#62;</td><td><a href="http://www.{{ current_site.domain }}">http://www.{{ current_site.domain }}</a></td>
     </tr>
     <tr>
-      <td>[WFH.io](http://www.{{ request.site.domain }})</td><td><a href="http://www.{{ request.site.domain }}">WFH.io</a></td>
+      <td>[{{ current_site.name }}](http://www.{{ current_site.domain }})</td><td><a href="http://www.{{ current_site.domain }}">{{ current_site.name }}</a></td>
     </tr>
     <tr>
-      <td>&#60;doesnotexist@{{ request.site.domain }}&#62;</td><td><a href="mailto:doesnotexist@{{ request.site.domain }}">doesnotexist@{{ request.site.domain }}</a></td>
+      <td>&#60;doesnotexist@{{ current_site.domain }}&#62;</td><td><a href="mailto:doesnotexist@{{ current_site.domain }}">doesnotexist@{{ current_site.domain }}</a></td>
     </tr>
     <tr>
       <td>

--- a/tramcar/settings.py
+++ b/tramcar/settings.py
@@ -51,7 +51,6 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.contrib.sites.middleware.CurrentSiteMiddleware',
 ]
 
 ROOT_URLCONF = 'tramcar.urls'
@@ -67,6 +66,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
+                'job_board.context_processors.get_site',
             ],
         },
     },


### PR DESCRIPTION
This commit removes the usage of CurrentSiteManager as we were running
into some issues with it.  Whilst it made filtering queries much easier
using on_site, it required you to have a custom settings.py for each
site with a unique SITE_ID in it for the site in question.  This adds a
fair bit of overhead when deploying new sites as you then need a
site-specific settings.yml file, a site-specific wsgi file, and a
web server configuration that points the specific site at the
site-specific wsgi file.CurrentSiteManager.  Also, while not 100%
confirmed, it appeared that /admin was then site-specific, meaning you
didn't have a global /admin to manage all sites in one pane.

Since CurrentSiteManager adds site to the request object, we needed to
create a custom context processor (get_site) which gives us access to
the site in all templates.  This is most importantly needed for
base.html, since we do not have a view-specific context dict where we
can append the site to.

Lastly, we update views.py to restrict categories and companies to the
site in question when adding/editing jobs.

Closes #41
