### PR TITLE
Move signals out of site_config.py

### DIFF
--- a/job_board/apps.py
+++ b/job_board/apps.py
@@ -1,7 +1,21 @@
 from __future__ import unicode_literals
 
 from django.apps import AppConfig
+from django.db.models.signals import post_migrate
+from django.db.models.signals import post_save
 
 
 class JobBoardConfig(AppConfig):
     name = 'job_board'
+
+    def ready(self):
+        from django.contrib.sites.models import Site
+
+        from job_board.signals import gen_site_config_post_migrate
+        from job_board.signals import gen_site_config_post_save
+
+        post_save.connect(gen_site_config_post_save, sender=Site)
+        # NOTE: We list sites before job_board in INSTALLED_APPS, failing to
+        #       do that will result in this post_migrate signal firing before
+        #       the default site has been created.
+        post_migrate.connect(gen_site_config_post_migrate, sender=self)

--- a/job_board/models/site_config.py
+++ b/job_board/models/site_config.py
@@ -1,43 +1,8 @@
 from __future__ import unicode_literals
 
-from django.dispatch import receiver
 from django.db import models
 from django.contrib.sites.models import Site
-from django.core.exceptions import ObjectDoesNotExist
 from django.utils.encoding import python_2_unicode_compatible
-
-
-# NOTE: This uses signals to auto-create a SiteConfig object when a site is
-#       added.  This saves the admin from having to manually create the site's
-#       SiteConfig after a site is added.
-@receiver(models.signals.post_save, sender=Site)
-def gen_site_config_post_save(sender, **kwargs):
-    if kwargs.get('created', True):
-        site = kwargs.get('instance')
-        SiteConfig.objects.get_or_create(
-            site=site,
-            admin_email='admin@%s' % site.domain
-        )
-
-
-# NOTE: The above (gen_site_config) used to work for the initial site created
-#       by the sites framework, however with the Django 1.10 upgrade this no
-#       worked.  This separate handler is to ensure that the initial
-#       example.com site gets a SiteConfig entry created also.
-@receiver(models.signals.post_migrate)
-def gen_site_config_post_migrate(plan, **kwargs):
-    # A migration of the `django.contrib.sites` app was applied.
-    if plan and any(migration.app_label == 'sites' for migration, _ in plan):
-        try:
-            site = Site.objects.get(name='example.com')
-        except ObjectDoesNotExist:
-            pass
-        else:
-            SiteConfig.objects.get_or_create(
-                site=site,
-                admin_email='admin@example.com',
-                remote=False
-            )
 
 
 @python_2_unicode_compatible

--- a/job_board/signals.py
+++ b/job_board/signals.py
@@ -1,0 +1,33 @@
+from __future__ import unicode_literals
+
+from django.core.exceptions import ObjectDoesNotExist
+from django.contrib.sites.models import Site
+
+from job_board.models.site_config import SiteConfig
+
+
+def gen_site_config_post_save(sender, **kwargs):
+    #from job_board.models.site_config import SiteConfig
+    if kwargs.get('created', True):
+        site = kwargs.get('instance')
+        SiteConfig.objects.get_or_create(
+            site=site,
+            admin_email='admin@%s' % site.domain
+        )
+
+
+def gen_site_config_post_migrate(plan, **kwargs):
+    # A migration of the `django.contrib.sites` app was applied.
+    #from django.contrib.sites.models import Site
+    #from job_board.models.site_config import SiteConfig
+    if plan and any(migration.app_label == 'sites' for migration, _ in plan):
+        try:
+            site = Site.objects.get(name='example.com')
+        except ObjectDoesNotExist as e:
+            pass
+        else:
+            SiteConfig.objects.get_or_create(
+                site=site,
+                admin_email='admin@example.com',
+                remote=False
+            )

--- a/tramcar/settings.py
+++ b/tramcar/settings.py
@@ -30,7 +30,13 @@ ALLOWED_HOSTS = []
 
 # Application definition
 
+# NOTE: We deliberately put django.contrib.sites before
+#       job_board.apps.JobBoardConfig so that sites' migrations run before
+#       job_board. This is a hack and we need to figure out how to add
+#       post_migrate signals to SitesConfig.
+
 INSTALLED_APPS = [
+    'django.contrib.sites',
     'job_board.apps.JobBoardConfig',
     'django.contrib.admin',
     'django.contrib.auth',
@@ -38,7 +44,6 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'django.contrib.sites',
     'bootstrapform',
 ]
 


### PR DESCRIPTION
This commit moves the signals into a separate signals.py file, and
moves the senders to apps.py.
# NOTE

The post_migrate signal fires on the job_board app, and by default this
app's migrations run before the sites app's migrations run. This results
in gen_site_config_post_migrate() failing since the example.com site
does not yet exist. To circumvent, we move the job_board app below the
sites app in settings.py so that example.com gets created before we try
to query for it. We will need to revisit this in future to see what the
more appropriate thing to do is.
