### PR TITLE
Remove django-bootstrap-form

### DIFF
--- a/job_board/forms.py
+++ b/job_board/forms.py
@@ -1,17 +1,58 @@
-from django.forms import ModelForm
+from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
+from django import forms
 
 from job_board.models.company import Company
 from job_board.models.job import Job
 
 
-class JobForm(ModelForm):
+class JobForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super(JobForm, self).__init__(*args, **kwargs)
+        self.label_suffix = ''
+        self.fields['company'].widget.attrs['class'] = 'form-control'
+        self.fields['title'].widget.attrs['class'] = 'form-control'
+        self.fields['description'].widget.attrs['class'] = 'form-control'
+        self.fields['application_info'].widget.attrs['class'] = 'form-control'
+        self.fields['country'].widget.attrs['class'] = 'form-control'
+        self.fields['location'].widget.attrs['class'] = 'form-control'
+        self.fields['remote'].widget.attrs['class'] = 'form-control'
+        self.fields['email'].widget.attrs['class'] = 'form-control'
+        self.fields['category'].widget.attrs['class'] = 'form-control'
+
     class Meta:
         model = Job
         fields = ['company', 'title', 'description', 'application_info',
                   'country', 'location', 'remote', 'email', 'category']
 
 
-class CompanyForm(ModelForm):
+class CompanyForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super(CompanyForm, self).__init__(*args, **kwargs)
+        self.label_suffix = ''
+        self.fields['name'].widget.attrs['class'] = 'form-control'
+        self.fields['name'].widget.attrs['class'] = 'form-control'
+        self.fields['url'].widget.attrs['class'] = 'form-control'
+        self.fields['country'].widget.attrs['class'] = 'form-control'
+        self.fields['twitter'].widget.attrs['class'] = 'form-control'
+        self.fields['site'].widget=forms.HiddenInput()
+
     class Meta:
         model = Company
-        fields = ['name', 'url', 'country', 'twitter']
+        fields = ['name', 'url', 'country', 'twitter', 'site']
+
+
+class CssAuthenticationForm(AuthenticationForm):
+    def __init__(self, *args, **kwargs):
+        super(CssAuthenticationForm, self).__init__(*args, **kwargs)
+        self.label_suffix = ''
+        self.fields['username'].widget.attrs['class'] = 'form-control'
+        self.fields['password'].widget.attrs['class'] = 'form-control'
+
+
+class CssUserCreationForm(UserCreationForm):
+    def __init__(self, *args, **kwargs):
+        super(CssUserCreationForm, self).__init__(*args, **kwargs)
+        self.label_suffix = ''
+        self.fields['username'].widget.attrs['class'] = 'form-control'
+        self.fields['password1'].widget.attrs['class'] = 'form-control'
+        self.fields['password2'].widget.attrs['class'] = 'form-control'

--- a/job_board/templates/job_board/companies_edit.html
+++ b/job_board/templates/job_board/companies_edit.html
@@ -1,11 +1,21 @@
 {% extends "job_board/base.html" %}
 
-{% load bootstrap %}
-
 {% block content %}
+{% include "job_board/errors.html" %}
+
 <form action="{% url 'companies_edit' company.id %}" method="post">
-    {% csrf_token %}
-    {{ form|bootstrap }}
-    <input type="submit" class="btn btn-default" value="Submit" />
+  {% csrf_token %}
+  {% for field in form %}
+  {% if field.is_hidden %}
+  {{ form.site }}
+  {% else %}
+  <div class="form-group">
+    {{ field.label_tag }}
+    {{ field }}
+    <p class="help-block">{{ field.help_text }}</p>
+  </div>
+  {% endif %}
+  {% endfor %}
+  <input type="submit" class="btn btn-default" value="Submit" />
 </form>
 {% endblock %}

--- a/job_board/templates/job_board/companies_new.html
+++ b/job_board/templates/job_board/companies_new.html
@@ -1,11 +1,21 @@
 {% extends "job_board/base.html" %}
 
-{% load bootstrap %}
-
 {% block content %}
+{% include "job_board/errors.html" %}
+
 <form action="{% url 'companies_new' %}" method="post">
   {% csrf_token %}
-  {{ form|bootstrap }}
+  {% for field in form %}
+  {% if field.is_hidden %}
+  {{ form.site }}
+  {% else %}
+  <div class="form-group">
+    {{ field.label_tag }}
+    {{ field }}
+    <p class="help-block">{{ field.help_text }}</p>
+  </div>
+  {% endif %}
+  {% endfor %}
   <input type="submit" class="btn btn-default" value="Submit" />
 </form>
 {% endblock %}

--- a/job_board/templates/job_board/errors.html
+++ b/job_board/templates/job_board/errors.html
@@ -1,0 +1,19 @@
+{% if form.errors %}
+<div class="panel panel-danger">
+  <div class="panel-heading">
+    <h3 class="panel-title">{{ form.errors|length }} error(s) prevented your resource from being saved</h3>
+  </div>
+  <div class="panel-body">
+    <ul>
+    {% for key, errors in form.errors.items %}
+      <li>{{ key|capfirst }}</li>
+      <ul>
+      {% for error in errors %}
+        <li>{{ error }}</li>
+      {% endfor %}
+      </ul>
+    {% endfor %}
+    </ul>
+  </div>
+</div>
+{% endif %}

--- a/job_board/templates/job_board/jobs_edit.html
+++ b/job_board/templates/job_board/jobs_edit.html
@@ -1,17 +1,23 @@
 {% extends "job_board/base.html" %}
 
-{% load bootstrap %}
-
 {% block content %}
+{% include "job_board/errors.html" %}
+
 <div class="row">
   <div class="col-md-4">
     {% include "job_board/markdown.html" %}
   </div>
   <div class="col-md-8">
     <form action="{% url 'jobs_edit' job.id %}" method="post">
-        {% csrf_token %}
-        {{ form|bootstrap }}
-        <input type="submit" class="btn btn-default" value="Submit" />
+      {% csrf_token %}
+      {% for field in form %}
+      <div class="form-group">
+        {{ field.label_tag }}
+        {{ field }}
+        <p class="help-block">{{ field.help_text }}</p>
+      </div>
+      {% endfor %}
+      <input type="submit" class="btn btn-default" value="Submit" />
     </form>
   </div>
 </div>

--- a/job_board/templates/job_board/jobs_new.html
+++ b/job_board/templates/job_board/jobs_new.html
@@ -1,8 +1,8 @@
 {% extends "job_board/base.html" %}
 
-{% load bootstrap %}
-
 {% block content %}
+{% include "job_board/errors.html" %}
+
 <div class="row">
   <div class="col-md-4">
     {% include "job_board/markdown.html" %}
@@ -10,7 +10,13 @@
   <div class="col-md-8">
     <form action="{% url 'jobs_new' %}" method="post">
       {% csrf_token %}
-      {{ form|bootstrap }}
+      {% for field in form %}
+      <div class="form-group">
+        {{ field.label_tag }}
+        {{ field }}
+        <p class="help-block">{{ field.help_text }}</p>
+      </div>
+      {% endfor %}
       <input type="submit" class="btn btn-default" value="Submit" />
     </form>
   </div>

--- a/job_board/templates/registration/login.html
+++ b/job_board/templates/registration/login.html
@@ -2,18 +2,22 @@
 
 {% block header %}Login{% endblock %}
 
-{% load bootstrap %}
-
 {% block content %}
+{% include "job_board/errors.html" %}
+
 <form method="post" action="{% url 'login' %}">
   {% csrf_token %}
-
-  {{ form|bootstrap}}
-
+  {% for field in form %}
+  <div class="form-group">
+    {{ field.label_tag }}
+    {{ field }}
+    <p class="help-block">{{ field.help_text }}</p>
+  </div>
+  {% endfor %}
   <button type="submit" class="btn btn-default">Login</button>
   <input type="hidden" name="next" value="{{ next }}" />
 </form>
 
 {# Assumes you setup the password_reset view in your URLconf #}
-<p><a href="{% url 'password_reset' %}">Lost password?</a></p>
+{# <p><a href="{% url 'password_reset' %}">Lost password?</a></p> #}
 {% endblock %}

--- a/job_board/templates/registration/register.html
+++ b/job_board/templates/registration/register.html
@@ -2,14 +2,18 @@
 
 {% block header %}Register{% endblock %}
 
-{% load bootstrap %}
-
 {% block content %}
+{% include "job_board/errors.html" %}
+
 <form action="{% url 'register' %}" method="post">
   {% csrf_token %}
-
-  {{ form|bootstrap }}
-
+  {% for field in form %}
+  <div class="form-group">
+    {{ field.label_tag }}
+    {{ field }}
+    <p class="help-block">{{ field.help_text }}</p>
+  </div>
+  {% endfor %}
   <input type="submit" class="btn btn-default" value="Create">
 </form>
 {% endblock %}

--- a/job_board/views/companies.py
+++ b/job_board/views/companies.py
@@ -31,17 +31,24 @@ def companies_index(request):
 @login_required(login_url='/login/')
 def companies_new(request):
     title = 'Add a Company'
+    site = get_current_site(request)
+
     if request.method == 'POST':
         form = CompanyForm(request.POST)
         if form.is_valid():
             company = form.save(commit=False)
-            company.site_id = get_current_site(request).id
+            company.site_id = site.id
             company.user_id = request.user.id
             company.save()
+
             return HttpResponseRedirect(reverse('companies_show',
                                                 args=(company.id,)))
     else:
-        form = CompanyForm()
+        # NOTE: site will be displayed in the HTML form as a hidden field, we
+        #       need to find a way to set this in CompanyForm so validation
+        #       passes, without actually putting it in the HTML
+        form = CompanyForm(initial={'site': site})
+
     context = {'form': form, 'title': title}
     return render(request, 'job_board/companies_new.html', context)
 

--- a/job_board/views/misc.py
+++ b/job_board/views/misc.py
@@ -1,17 +1,18 @@
-from django.contrib.auth.forms import UserCreationForm
 from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 
+from job_board.forms import CssUserCreationForm
+
 
 def register(request):
     if request.method == 'POST':
-        form = UserCreationForm(request.POST)
+        form = CssUserCreationForm(request.POST)
         if form.is_valid():
             new_user = form.save()
             return HttpResponseRedirect(reverse('jobs_index'))
     else:
-        form = UserCreationForm()
+        form = CssUserCreationForm()
     return render(request, "registration/register.html", {
         'form': form,
     })

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 Django==1.10.1
-django-bootstrap-form==3.2.1
 Markdown==2.6.6
 wheel==0.24.0

--- a/tramcar/settings.py
+++ b/tramcar/settings.py
@@ -44,7 +44,6 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'bootstrapform',
 ]
 
 MIDDLEWARE_CLASSES = [

--- a/tramcar/urls.py
+++ b/tramcar/urls.py
@@ -15,9 +15,14 @@ Including another URLconf
 """
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.contrib.auth import views as auth_views
+
+from job_board.forms import CssAuthenticationForm
 
 urlpatterns = [
     url(r'^', include('job_board.urls')),
     url(r'^admin/', admin.site.urls),
-    url('^', include('django.contrib.auth.urls')),
+    #url('^', include('django.contrib.auth.urls')),
+    url(r'^login/$', auth_views.login, {'authentication_form': CssAuthenticationForm}, name='login'),
+    url(r'^logout/$', auth_views.logout, name='logout'),
 ]


### PR DESCRIPTION
This commit largely does two things:
1. Removes django-bootstrap-form, which means we've had to add a bunch
   of CSS stylings to our forms
2. Adds site to the fields in CompanyForm, which allows us to properly
   validate the uniqueness of name & site in CompanyForm

Regarding point 2, we now pass site as a hidden form field in
CompanyForm, which is probably something we want to avoid doing.  I
looked at numerous ways of avoiding this but could never get the
CompanyForm to save.

Closes #50
