### PR TITLE
Resolve flake8 issue

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,6 +2,4 @@
 exclude =
     .venv,
     job_board/migrations,
-    tramcar/settings.py,
-    # FIXME
-    job_board/views/__init__.py
+    tramcar/settings.py

--- a/job_board/management/commands/expire.py
+++ b/job_board/management/commands/expire.py
@@ -1,9 +1,10 @@
 from datetime import timedelta
 
 from django.core.management.base import BaseCommand
+from django.contrib.sites.models import Site
 from django.utils import timezone
 
-from job_board.models import Job, Site
+from job_board.models.job import Job
 
 
 class Command(BaseCommand):

--- a/job_board/urls.py
+++ b/job_board/urls.py
@@ -1,42 +1,48 @@
 from django.conf.urls import url
 
-from . import views
-
+import job_board.views.jobs as jobs
+import job_board.views.categories as categories
+import job_board.views.companies as companies
+import job_board.views.misc as misc
 
 urlpatterns = [
-    url(r'^$', views.jobs_index, name='jobs_index'),
-    url(r'^jobs/$', views.jobs_index, name='jobs_index'),
-    url(r'^jobs/new/$', views.jobs_new, name='jobs_new'),
-    url(r'^jobs/mine/$', views.jobs_mine, name='jobs_mine'),
-    url(r'^jobs/(?P<job_id>[0-9]+)/$', views.jobs_show, name='jobs_show'),
+    url(r'^$', jobs.jobs_index, name='jobs_index'),
+    url(r'^jobs/$', jobs.jobs_index, name='jobs_index'),
+    url(r'^jobs/new/$', jobs.jobs_new, name='jobs_new'),
+    url(r'^jobs/mine/$', jobs.jobs_mine, name='jobs_mine'),
+    url(r'^jobs/(?P<job_id>[0-9]+)/$', jobs.jobs_show, name='jobs_show'),
     url(
         r'^jobs/(?P<job_id>[0-9]+)/activate$',
-        views.jobs_activate,
+        jobs.jobs_activate,
         name='jobs_activate'
     ),
     url(
         r'^jobs/(?P<job_id>[0-9]+)/expire$',
-        views.jobs_expire,
+        jobs.jobs_expire,
         name='jobs_expire'
     ),
-    url(r'^jobs/(?P<job_id>[0-9]+)/edit$', views.jobs_edit, name='jobs_edit'),
-    url(r'^categories/$', views.categories_index, name='categories_index'),
+    url(r'^jobs/(?P<job_id>[0-9]+)/edit$', jobs.jobs_edit, name='jobs_edit'),
+    url(
+        r'^categories/$',
+        categories.categories_index,
+        name='categories_index'
+    ),
     url(
         r'^categories/(?P<category_id>[0-9]+)/$',
-        views.categories_show,
+        categories.categories_show,
         name='categories_show'
     ),
-    url(r'^companies/$', views.companies_index, name='companies_index'),
-    url(r'^companies/new$', views.companies_new, name='companies_new'),
+    url(r'^companies/$', companies.companies_index, name='companies_index'),
+    url(r'^companies/new$', companies.companies_new, name='companies_new'),
     url(
         r'^companies/(?P<company_id>[0-9]+)/$',
-        views.companies_show,
+        companies.companies_show,
         name='companies_show'
     ),
     url(
         r'^companies/(?P<company_id>[0-9]+)/edit$',
-        views.companies_edit,
+        companies.companies_edit,
         name='companies_edit'
     ),
-    url(r'^register$', views.register, name='register'),
+    url(r'^register$', misc.register, name='register'),
 ]

--- a/job_board/views/__init__.py
+++ b/job_board/views/__init__.py
@@ -1,4 +1,0 @@
-from categories import *
-from companies import *
-from jobs import *
-from misc import *


### PR DESCRIPTION
This commit removes the flake8 exclusion on
job_board/views/**init**.py by changing how we import views.

Additionally, we fix the expire management command which is broken in
its current state.
