### PR TITLE
Hide remote field on job when job board is remote

### DIFF
--- a/job_board/templates/job_board/jobs_show.html
+++ b/job_board/templates/job_board/jobs_show.html
@@ -68,6 +68,10 @@
         <p>{{ job.description_md | safe }}</p>
         <h4><mark>Application Info</mark></h4>
         <p>{{ job.application_info_md | safe }}</p>
+        {% if not remote %}
+        <h4><mark>Remote</mark></h4>
+        <p>{{ job.remote }}</p>
+        {% endif %}
         {% if job.country %}
         <h4><mark>Country</mark></h4>
         <p>{{ job.country }}</p>


### PR DESCRIPTION
This commit udpates jobs.py view to remove the remote field when the
job board from the forms when the job board is remote.  The remote
field is then set when the job is saved.

Additionally, we display on individual job posts whether the job
supports remote working.  This should eventually be replaced by an
icon or something a bit more visible.
