### PR TITLE
Actually remove SECRET_KEY value from settings.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,5 @@ install:
 # command to run tests
 script:
   - flake8 .
+  - sed -i.bak "s/^SECRET_KEY = ''$/SECRET_KEY = 'randomstring'/g" tramcar/settings.py
   - python manage.py test

--- a/tramcar/settings.py
+++ b/tramcar/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.9/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'r2LC3TnxTf9Qw8tkqo3g3CSTRmtYxEvG3t0sPqVhE581mLeLEE'
+SECRET_KEY = ''
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
In a previous commit we prepared for the removal of the SECRET_KEY
value from tramcar/settings.py, but our testing put a value back. :)

This commit actually removes the value as intended.
