### PR TITLE
Hide certain columns when on smaller displays

### DIFF
--- a/job_board/templates/job_board/companies_index.html
+++ b/job_board/templates/job_board/companies_index.html
@@ -6,8 +6,8 @@
   <thead>
     <tr>
       <th>Name</th>
-      <th>URL</th>
-      <th>Twitter</th>
+      <th class="hidden-xs hidden-sm">URL</th>
+      <th class="hidden-xs hidden-sm">Twitter</th>
       <th>Total Jobs</th>
       <th>Active Jobs</th>
     </tr>
@@ -15,8 +15,8 @@
   {% for company in companies %}
   <tr>
     <td><a href="{% url 'companies_show' company.id %}">{{ company.name }}</a></td>
-    <td><a href="{{ company.url }}">{{ company.url }}</a></td>
-    <td><a href="https://www.twitter.com/{{ company.twitter }}">{{ company.twitter }}</a></td>
+    <td class="hidden-xs hidden-sm"><a href="{{ company.url }}">{{ company.url }}</a></td>
+    <td class="hidden-xs hidden-sm"><a href="https://www.twitter.com/{{ company.twitter }}">{{ company.twitter }}</a></td>
     <td>{{ company.paid_jobs.count }}</td>
     <td>{{ company.active_jobs.count }}</td>
   </tr>

--- a/job_board/templates/job_board/companies_show.html
+++ b/job_board/templates/job_board/companies_show.html
@@ -35,10 +35,10 @@
     <table class="table">
       <thead>
         <tr>
-          <th>Post Date</th>
+          <th>Date</th>
           <th>Title</th>
           <th>Country</th>
-          <th>Category</th>
+          <th class="hidden-xs hidden-sm">Category</th>
           <th>Expired</th>
         </tr>
       </thead>
@@ -47,7 +47,9 @@
         <td>{{ job.paid_at|date:'Y-m-d' }}</td>
         <td><a href="{% url 'jobs_show' job.id %}">{{ job.title }}</a></td>
         <td>{{ job.format_country }}</td>
-        <td><a href="{% url 'categories_show' job.category.id %}">{{ job.category.name }}</a></td>
+        <td class="hidden-xs hidden-sm">
+          <a href="{% url 'categories_show' job.category.id %}"><span class="label label-primary">{{ job.category.name }}</span></a>
+        </td>
         <td>
           {% if job.paid_at and not job.expired_at %}
           <span class="label label-success %>">No</span>

--- a/job_board/templates/job_board/jobs_index.html
+++ b/job_board/templates/job_board/jobs_index.html
@@ -5,9 +5,8 @@
 <table class="table">
   <thead>
     <tr>
-      <th>Post Date</th>
+      <th>Date</th>
       <th>Title</th>
-      <th>Company</th>
       <th>Country</th>
       <th>Category</th>
     </tr>
@@ -15,10 +14,14 @@
   {% for job in jobs %}
   <tr>
     <td>{{ job.paid_at|date:'Y-m-d' }}</td>
-    <td><a href="{% url 'jobs_show' job.id %}">{{ job.title }}</a></td>
-    <td><a href="{% url 'companies_show' job.company.id %}">{{ job.company.name }}</a></td>
+    <td>
+      <p><a href="{% url 'jobs_show' job.id %}">{{ job.title }}</a></p>
+      <p><small><strong>@&nbsp;{{ job.company.name }}</strong></small></p>
+    </td>
     <td>{{ job.format_country }}</td>
-    <td><a href="{% url 'categories_show' job.category.id %}">{{ job.category.name }}</a></td>
+    <td>
+      <a href="{% url 'categories_show' job.category.id %}"><span class="label label-primary">{{ job.category.name }}</span></a>
+    </td>
   </tr>
   {% endfor %}
 </table>

--- a/job_board/templates/job_board/jobs_mine.html
+++ b/job_board/templates/job_board/jobs_mine.html
@@ -5,21 +5,24 @@
 <table class="table">
   <thead>
     <tr>
-      <th>Post Date</th>
+      <th>Date</th>
       <th>Title</th>
-      <th>Company</th>
-      <th>Country</th>
-      <th>Category</th>
+      <th class="hidden-xs hidden-sm">Country</th>
+      <th class="hidden-xs hidden-sm">Category</th>
       <th>Expired</th>
     </tr>
   </thead>
   {% for job in jobs %}
   <tr>
     <td>{{ job.created_at|date:'Y-m-d' }}</td>
-    <td><a href="{% url 'jobs_show' job.id %}">{{ job.title }}</a></td>
-    <td><a href="{% url 'companies_show' job.company.id %}">{{ job.company.name }}</a></td>
-    <td>{{ job.format_country }}</td>
-    <td><a href="{% url 'categories_show' job.category.id %}">{{ job.category.name }}</a></td>
+    <td>
+      <p><a href="{% url 'jobs_show' job.id %}">{{ job.title }}</a></p>
+      <p><small><strong>@&nbsp;{{ job.company.name }}</strong></small></p>
+    </td>
+    <td class="hidden-xs hidden-sm">{{ job.format_country }}</td>
+    <td class="hidden-xs hidden-sm">
+      <a href="{% url 'categories_show' job.category.id %}"><span class="label label-primary">{{ job.category.name }}</span></a>
+    </td>
     <td>
       {% if not job.paid_at and not job.expired_at %}
       <span class="label label-warning %>">Unpaid</span>

--- a/job_board/templates/job_board/jobs_show.html
+++ b/job_board/templates/job_board/jobs_show.html
@@ -88,7 +88,9 @@
         <p>{{ job.location }}</p>
         {% endif %}
         <h4><mark>Category</mark></h4>
-        <p><a href="{% url 'categories_show' job.category.id %}">{{ job.category }}</a></p>
+        <p>
+          <a href="{% url 'categories_show' job.category.id %}"><span class="label label-primary">{{ job.category.name }}</span></a>
+        </p>
         {% if user.id == job.id or user.is_staff %}
         <h4><mark>E-mail</mark></h4>
         <p>{{ job.email }}</p>


### PR DESCRIPTION
This commit makes our templates display nicer on small mobile devices
by hiding specific columns in that view size.  We also represent the
job category with a Bootstrap label.
