### PR TITLE
Remove www from domain in email template

### DIFF
--- a/job_board/templates/job_board/emails/expired.txt
+++ b/job_board/templates/job_board/emails/expired.txt
@@ -3,9 +3,9 @@ Hi there!
 Thank you for using {{ job.site.domain }}.  This e-mail is to notify you that
 the following post has now expired:
 
-https://www.{{ job.site.domain }}{% url 'jobs_show' job.id %}
+https://{{ job.site.domain }}{% url 'jobs_show' job.id %}
 
-If you are still hiring for this position, please log into https://www.{{ job.site.domain }}/
+If you are still hiring for this position, please log into https://{{ job.site.domain }}/
 and then re-post this job.
 
 As always, let us know if you have any questions or comments, and thank you again

--- a/job_board/templates/job_board/markdown.html
+++ b/job_board/templates/job_board/markdown.html
@@ -8,10 +8,10 @@
       <td>__Strong Emphasis__</td><td><strong>Strong Emphasis</strong></td>
     </tr>
     <tr>
-      <td>&#60;http://www.{{ current_site.domain }}&#62;</td><td><a href="http://www.{{ current_site.domain }}">http://www.{{ current_site.domain }}</a></td>
+      <td>&#60;http://{{ current_site.domain }}&#62;</td><td><a href="http://{{ current_site.domain }}">http://{{ current_site.domain }}</a></td>
     </tr>
     <tr>
-      <td>[{{ current_site.name }}](http://www.{{ current_site.domain }})</td><td><a href="http://www.{{ current_site.domain }}">{{ current_site.name }}</a></td>
+      <td>[{{ current_site.name }}](http://{{ current_site.domain }})</td><td><a href="http://{{ current_site.domain }}">{{ current_site.name }}</a></td>
     </tr>
     <tr>
       <td>&#60;doesnotexist@{{ current_site.domain }}&#62;</td><td><a href="mailto:doesnotexist@{{ current_site.domain }}">doesnotexist@{{ current_site.domain }}</a></td>


### PR DESCRIPTION
We currently hardcode www in the email template, which causes an issue
if the domain is already configured with www.