### PR TITLE
Job admin doesn't show when user is not an admin

### DIFF
--- a/job_board/templates/job_board/jobs_show.html
+++ b/job_board/templates/job_board/jobs_show.html
@@ -19,13 +19,12 @@
         <a href="{% url 'companies_show' job.company.id %}" title="View all of company's jobs"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
       </div>
     </div>
-    {% if user.id == job.id or user.is_staff %}
+    {% if user.id == job.user_id or user.is_staff %}
     <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title">Job Admin</h3>
       </div>
       <div class="panel-body">
-
         {% if user.is_staff %}
         <h4><mark>Posted By</mark></h4>
         <p>{{ user.username }} (UID: {{ user.id }})</p>


### PR DESCRIPTION
We have a bug in the jobs_show.html template which show the job admin
panel when a user owns the job or if the user is an admin.  Currently,
we have a typo ensuring that user.id == job.id, but this should be
user.id == job.user_id.  This typo prevents non-admins from being
seeing the job admin panel.