### PR TITLE
Do not make country required

### DIFF
--- a/job_board/forms.py
+++ b/job_board/forms.py
@@ -41,6 +41,29 @@ class JobForm(forms.ModelForm):
                   'remote', 'city', 'state', 'country', 'location', 'email',
                   'category']
 
+    def clean(self):
+        cleaned_data = super(JobForm, self).clean()
+        city = cleaned_data.get("city")
+        state = cleaned_data.get("state")
+        country = cleaned_data.get("country")
+        remote = cleaned_data.get("remote")
+        if not remote:
+            if not city:
+                self.add_error(
+                    "city",
+                    "City is required when the job is note remote"
+                )
+            if not state:
+                self.add_error(
+                    "state",
+                    "State is required when the job is not remote"
+                )
+            if not country:
+                self.add_error(
+                    "country",
+                    "Country is required when the job is not remote"
+                )
+
 
 class JobRemoteForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):

--- a/job_board/templates/job_board/jobs_show.html
+++ b/job_board/templates/job_board/jobs_show.html
@@ -69,14 +69,17 @@
         <p>{{ job.description_md | safe }}</p>
         <h4><mark>Application Info</mark></h4>
         <p>{{ job.application_info_md | safe }}</p>
+        {# If site is remote then we do not indicate that the job is remote since all jobs on that site are remote #}
         {% if not remote %}
-          {% if job.remote != "No" %}
+          {% if job.remote == "Yes" %}
           <h4><mark>Remote</mark></h4>
           <p>{{ job.remote }}</p>
-          {% endif %}
+          {% else %}
           <h4><mark>City</mark></h4>
           <p>{{ job.city }}, {{ job.state }}, {{ job.country }}</p>
-        {% else %}
+          {% endif %}
+        {% endif %}
+        {% if remote or job.remote == "Yes" %}
           {% if job.country %}
           <h4><mark>Country</mark></h4>
           <p>{{ job.country }}</p>
@@ -90,7 +93,7 @@
         <p>
           <a href="{% url 'categories_show' job.category.id %}"><span class="label label-primary">{{ job.category.name }}</span></a>
         </p>
-        {% if user.id == job.id or user.is_staff %}
+        {% if user.id == job.user_id or user.is_staff %}
         <h4><mark>E-mail</mark></h4>
         <p>{{ job.email }}</p>
         {% endif %}

--- a/job_board/views/jobs.py
+++ b/job_board/views/jobs.py
@@ -55,9 +55,6 @@ def jobs_new(request):
             form = JobRemoteForm(request.POST)
         else:
             form = JobForm(request.POST)
-            # We cannot make country required on the model as this is optional
-            # when the job is remote
-            form.fields['country'].required = True
 
         if form.is_valid():
             job = form.save(commit=False)
@@ -72,9 +69,6 @@ def jobs_new(request):
             form = JobRemoteForm()
         else:
             form = JobForm()
-            # We cannot make country required on the model as this is optional
-            # when the job is remote
-            form.fields['country'].required = True
 
     # NOTE: By default, the company and category dropdowns will contain all
     #       instances across all sites, and the following limits this to
@@ -136,9 +130,6 @@ def jobs_edit(request, job_id):
             form = JobRemoteForm(request.POST, instance=job)
         else:
             form = JobForm(request.POST, instance=job)
-            # We cannot make country required on the model as this is optional
-            # when the job is remote
-            form.fields['country'].required = True
 
         if form.is_valid():
             job = form.save(commit=False)
@@ -154,9 +145,6 @@ def jobs_edit(request, job_id):
             form = JobRemoteForm(instance=job)
         else:
             form = JobForm(instance=job)
-            # We cannot make country required on the model as this is optional
-            # when the job is remote
-            form.fields['country'].required = True
 
     form.fields['company'].queryset = Company.objects.filter(
                                           site_id=site.id


### PR DESCRIPTION
Currently, on a non remote job board when adding a remote job country
is required, however for many remote jobs the country you are based in
is not applicable.  This commit does the following:

- removes setting the country field in the jobs views to required when
  the job is not remote
- updates the job form to validate that city/state/country are being
  set when the job is note remote
- updates how we display location details in the job show template and
  also fixes a bug where we should be checking job.user_id and not
  job.id