### PR TITLE
Send e-mail when job is posted

### DIFF
--- a/job_board/templates/job_board/emails/new_job_notification.txt
+++ b/job_board/templates/job_board/emails/new_job_notification.txt
@@ -1,0 +1,7 @@
+Hi there!
+
+Good news, {{ job.user.name }} posted a new job under {{ job.category.name }}.
+
+Details here:
+
+{{ protocol }}://{{ job.site.domain }}{% url 'jobs_show' job.id %}


### PR DESCRIPTION
This commit overrides the save() method on the Job model class to send
the site administrator an e-mail when a job is posted.  This is
necessary for the administrator to activate the job when a new post
comes in.

Closes #116