### PR TITLE
Add message flashing and create send_email helper

### DIFF
--- a/job_board/models/job.py
+++ b/job_board/models/job.py
@@ -5,10 +5,11 @@ import tweepy
 from django.db import models
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
-from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.conf import settings
 from django.utils import timezone
+
+from utils.misc import send_mail_with_helper
 
 from job_board.models.category import Category
 from job_board.models.company import Company
@@ -82,12 +83,11 @@ class Job(models.Model):
             context = {'job': self, 'protocol': sc.protocol}
             self.expired_at = timezone.now()
             self.save()
-            send_mail(
+            send_mail_with_helper(
                 'Your %s job has expired' % self.site.name,
                 render_to_string('job_board/emails/expired.txt', context),
                 sc.admin_email,
-                [self.email],
-                fail_silently=True,
+                [self.email]
             )
             return True
         else:

--- a/job_board/templates/job_board/_base.html
+++ b/job_board/templates/job_board/_base.html
@@ -52,6 +52,11 @@
       </div>
     </nav>
     <div class="container">
+      {% if messages %}
+      {% for message in messages %}
+      <div class="alert alert-{{ message.tags }}" role="alert">{{ message }}</div>
+      {% endfor %}
+      {% endif %}
       <h1>{{ title|default:current_site.name }}</h1>
       {% block content %}{% endblock %}
       <p class="text-center">

--- a/job_board/views/companies.py
+++ b/job_board/views/companies.py
@@ -1,3 +1,4 @@
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
@@ -40,6 +41,11 @@ def companies_new(request):
             company.site_id = site.id
             company.user_id = request.user.id
             company.save()
+
+            messages.success(
+                request,
+                'Your company has been successfully added'
+            )
 
             return HttpResponseRedirect(reverse('companies_show',
                                                 args=(company.id,)))
@@ -86,6 +92,12 @@ def companies_edit(request, company_id):
         form = CompanyForm(request.POST, instance=company)
         if form.is_valid():
             form.save()
+
+            messages.success(
+                request,
+                'Your company has been successfully updated'
+            )
+
             return HttpResponseRedirect(reverse('companies_show',
                                                 args=(company.id,)))
     else:

--- a/job_board/views/misc.py
+++ b/job_board/views/misc.py
@@ -1,8 +1,10 @@
-from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
+from django.contrib import messages
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
+
+from utils.misc import send_mail_with_helper
 
 from job_board.forms import ContactForm, CssUserCreationForm
 from job_board.models.site_config import SiteConfig
@@ -17,13 +19,19 @@ def contact(request):
             cd = form.cleaned_data
             # re-tag subject to make it more identifiable
             cd['subject'] = "[%s] %s" % (site.name.upper(), cd['subject'])
-            send_mail(
+            send_mail_with_helper(
                 cd['subject'],
                 cd['message'],
                 cd['email'],
-                [sc.admin_email],
-                fail_silently=True
+                [sc.admin_email]
             )
+
+            messages.success(
+                request,
+                "Thank you for your message, "
+                "we'll be back in touch as soon as possible"
+            )
+
             return HttpResponseRedirect(reverse('jobs_index'))
     else:
         form = ContactForm()
@@ -39,6 +47,13 @@ def register(request):
         form = CssUserCreationForm(request.POST)
         if form.is_valid():
             form.save()
+
+            messages.success(
+                request,
+                'Your account has been successfully created, '
+                'please log in to continue'
+            )
+
             return HttpResponseRedirect(reverse('jobs_index'))
     else:
         form = CssUserCreationForm()

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -1,0 +1,13 @@
+from django.core.mail import send_mail
+from django.conf import settings
+
+
+def send_mail_with_helper(subject, message, from_email, recipient_list):
+    if not settings.DEBUG:
+        send_mail(
+            subject,
+            message,
+            from_email,
+            recipient_list,
+            fail_silently=True,
+        )


### PR DESCRIPTION
This commit does the following:

1. Adds some initial message flashing so that a user knows that an
   e-mail has been sent, their account created, etc.
2. Creates a new misc utility file with a send_mail method that lets
   us only send e-mail notifications in production.

Point 2 is necessary because in development you do not necessarily
want e-mails flying around when you're testing things, and despite
fail_silently being passed in as True, we were still getting failures
when the mail system was not configured correctly.

Closes #94