### PR TITLE
Mask stripe/twitter keys in admin panel

### DIFF
--- a/job_board/admin.py
+++ b/job_board/admin.py
@@ -1,15 +1,20 @@
 from django.contrib import admin
 
+from job_board.forms import SiteConfigForm
 from job_board.models.category import Category
 from job_board.models.company import Company
 from job_board.models.country import Country
 from job_board.models.job import Job
 from job_board.models.site_config import SiteConfig
 
+
+class SiteConfigAdmin(admin.ModelAdmin):
+    form = SiteConfigForm
+
+
+# Register your models here.
 admin.site.register(Category)
 admin.site.register(Company)
 admin.site.register(Country)
 admin.site.register(Job)
-admin.site.register(SiteConfig)
-
-# Register your models here.
+admin.site.register(SiteConfig, SiteConfigAdmin)

--- a/job_board/forms.py
+++ b/job_board/forms.py
@@ -4,6 +4,7 @@ from django import forms
 
 from job_board.models.company import Company
 from job_board.models.job import Job
+from job_board.models.site_config import SiteConfig
 
 
 class ContactForm(forms.Form):
@@ -97,6 +98,34 @@ class CompanyForm(forms.ModelForm):
     class Meta:
         model = Company
         fields = ['name', 'url', 'country', 'twitter', 'site']
+
+
+class SiteConfigForm(forms.ModelForm):
+    class Meta:
+        model = SiteConfig
+        widgets = {
+            'stripe_secret_key': forms.PasswordInput(
+                                     render_value=True,
+                                     attrs={'class': 'vTextField'}
+                                 ),
+            'twitter_consumer_key': forms.PasswordInput(
+                                     render_value=True,
+                                     attrs={'class': 'vTextField'}
+                                 ),
+            'twitter_consumer_secret': forms.PasswordInput(
+                                           render_value=True,
+                                           attrs={'class': 'vTextField'}
+                                       ),
+            'twitter_access_token': forms.PasswordInput(
+                                        render_value=True,
+                                        attrs={'class': 'vTextField'}
+                                    ),
+            'twitter_access_token_secret': forms.PasswordInput(
+                                               render_value=True,
+                                               attrs={'class': 'vTextField'}
+                                           ),
+        }
+        fields = ('__all__')
 
 
 class CssAuthenticationForm(AuthenticationForm):


### PR DESCRIPTION
This commit creates a new SiteConfigForm, which uses the
forms.PasswordInput widget to mask stripe/twitter keys when viewed in
the admin panel.