### PR TITLE
Initial pass at Vagrantfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.swp
 db.sqlite3
+vagrant/.vagrant/

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,0 +1,83 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://atlas.hashicorp.com/search.
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.hostname = "tramcar"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = 512
+    vb.cpus = 1
+  end
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.verbose = "v"
+    ansible.playbook = "playbook.yml"
+  end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Define a Vagrant Push strategy for pushing to Atlas. Other push strategies
+  # such as FTP and Heroku are also available. See the documentation at
+  # https://docs.vagrantup.com/v2/push/atlas.html for more information.
+  # config.push.define "atlas" do |push|
+  #   push.app = "YOUR_ATLAS_USERNAME/YOUR_APPLICATION_NAME"
+  # end
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/vagrant/playbook.yml
+++ b/vagrant/playbook.yml
@@ -1,0 +1,38 @@
+---
+- hosts: all
+  gather_facts: false
+  tasks:
+    - raw: sudo apt-get install -y python
+
+- hosts: all
+  user: root
+  tasks:
+    - apt:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - tmux
+        - sqlite3
+        - python3
+        - python3-dev
+        - python-virtualenv
+        - mysql-server
+        - libmysqlclient-dev
+        - apache2
+        - libapache2-mod-wsgi-py3
+      become: yes
+    - git:
+        repo: https://github.com/wfhio/tramcar
+        dest: ~/tramcar
+    - pip:
+        requirements: ~/tramcar/requirements.txt
+        virtualenv: ~/tramcar/.venv
+        virtualenv_python: python3
+    - shell: |
+        . .venv/bin/activate
+        sed -i "s/SECRET_KEY = ''/SECRET_KEY = 'vagrant'/" tramcar/settings.py
+        python manage.py migrate
+        sqlite3 db.sqlite3 "UPDATE django_site SET domain='localhost' WHERE name='example.com';"
+        tmux new -d -s tramcar python manage.py runserver 0.0.0.0:8080
+      args:
+        chdir: ~/tramcar


### PR DESCRIPTION
This commit drops a Vagrantfile and ansible playbook to deploy tramcar
into a VM with vagrant and ansible.  There are several things still
left to do:

- deploy mysql and create appropriate users, databases, etc.
- create an Apache virtualhost and run Tramcar via Apache
- make the playbook idempotent (currently, we update
  tramcar/settings.py and a subsequent run will fail because the tree
  isn't clean