### PR TITLE
Fix bug in companies_show template

### DIFF
--- a/job_board/templates/job_board/companies_show.html
+++ b/job_board/templates/job_board/companies_show.html
@@ -25,7 +25,7 @@
         </h4>
         <p><a href="https://twitter.com/{{ company.twitter }}">{{ company.twitter }}</a></p>
         {% endif %}
-        {% if company.id == user.id or user.is_staff %}
+        {% if company.user.id == user.id or user.is_staff %}
         <a class="btn btn-default btn-sm" href="{% url 'companies_edit' company.id %}">Edit Company</a>
         {% endif %}
       </div>

--- a/job_board/templates/job_board/jobs_show.html
+++ b/job_board/templates/job_board/jobs_show.html
@@ -21,7 +21,7 @@
         <a href="{% url 'companies_show' job.company.id %}" title="View all of company's jobs"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
       </div>
     </div>
-    {% if user.id == job.user_id or user.is_staff %}
+    {% if user.id == job.user.id or user.is_staff %}
     <div class="panel panel-default">
       <div class="panel-heading">
         <h3 class="panel-title">Job Admin</h3>
@@ -123,7 +123,7 @@
         <p>
           <a href="{% url 'categories_show' job.category.id %}"><span class="label label-primary">{{ job.category.name }}</span></a>
         </p>
-        {% if user.id == job.user_id or user.is_staff %}
+        {% if user.id == job.user.id or user.is_staff %}
         <h4><mark>E-mail</mark></h4>
         <p>{{ job.email }}</p>
         {% endif %}


### PR DESCRIPTION
This commit fixes a bug in companies_show where we do not correctly
show the company edit link if the company owner is the current user
(we are checking company.id rather than company.user.id).

Note that we do actually have a test in place for this, however the
test was passing since in this instance company.id did match
user.id.

We also update jobs_show to use job.user.id instead of job.user_id.
This is simply done for consistency.