### PR TITLE
Minor bug fixes

### DIFF
--- a/job_board/templates/job_board/jobs_show.html
+++ b/job_board/templates/job_board/jobs_show.html
@@ -28,16 +28,16 @@
       <div class="panel-body">
         {% if user.is_staff %}
         <h4><mark>Posted By</mark></h4>
-        <p>{{ user.username }} (UID: {{ user.id }})</p>
+        <p>{{ job.user.username }} (UID: {{ job.user.id }})</p>
         {% endif %}
         <h4><mark>Status</mark></h4>
         <p>
           {% if not job.paid_at and not job.expired_at %}
-          <span class="label label-warning %>">Unpaid</span>
+          <span class="label label-warning">Unpaid</span>
           {% elif job.paid_at and not job.expired_at %}
-          <span class="label label-success %>">Paid</span>
+          <span class="label label-success">Paid</span>
           {% elif job.paid_at and job.expired_at %}
-          <span class="label label-warning %>">Expired</span>
+          <span class="label label-warning">Expired</span>
           {% endif %}
         </p>
         <div class="btn-group btn-group-sm button-group-margin">

--- a/job_board/views/jobs.py
+++ b/job_board/views/jobs.py
@@ -109,11 +109,12 @@ def jobs_show(request, job_id):
     site = get_current_site(request)
     # If the browsing user does not own the job, and the job has yet to be paid
     # for, then 404
-    if job.user_id != request.user.id and job.paid_at is None:
+    if (job.user.id != request.user.id and not request.user.is_staff and
+            job.paid_at is None):
         raise Http404("No Job matches the given query.")
     # If the browsing user owns the job, and the job is unpaid for, display the
     # job's created_at date instead of paid_at
-    if job.user_id == request.user.id and job.paid_at is None:
+    if job.user.id == request.user.id and job.paid_at is None:
         post_date = job.created_at
     else:
         post_date = job.paid_at


### PR DESCRIPTION
This commit fixes the following minor bugs:

1. Updates jobs_show view to permit admin user to view unpaid jobs
   belonging to other users.
2. Updates jobs_show template to show the correct user who has posted
   a given job.
3. Removes some `%>` cruft in jobs_show template which didn't need to
   be there.

This commit also fixes the failing tests that resulted from the change
in #3, and adds a fair number of new tests so we properly test on some
of this expected functionality that wasn't working. Note that we also
changed test_show_view_on_own_job_does_not_show_admin_expire_button to
test_show_view_on_own_job_shows_expire_button since a job owner should
be able to expire their own job.