### PR TITLE
Add margin to twitter icon

### DIFF
--- a/job_board/static/job_board/style.css
+++ b/job_board/static/job_board/style.css
@@ -13,6 +13,7 @@
 #twitter-button {
   margin-top:15px;
   margin-left:10px;
+  margin-right:10px;
 }
 
-body { padding-top: 70px; }
+body { padding-top: 50px; }


### PR DESCRIPTION
After changing the navbar to navbar-fixed-to, the twitter icon now has
no margin on the right side.  This change adds a margin to the right,
and also decreases body's padding-top to 50px.