### PR TITLE
Increase body's padding-top

### DIFF
--- a/job_board/static/job_board/style.css
+++ b/job_board/static/job_board/style.css
@@ -16,4 +16,4 @@
   margin-right:10px;
 }
 
-body { padding-top: 50px; }
+body { padding-top: 70px; }


### PR DESCRIPTION
In a recent commit we reduced this to 50px, but in doing so flash
messages are now flush with the navbar.  This commit returns body's
padding-top to 70px.