### PR TITLE
Initial pass at URL slugs

### DIFF
--- a/job_board/models/category.py
+++ b/job_board/models/category.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 from django.db import models
 from django.contrib.sites.models import Site
+from django.core.urlresolvers import reverse
+from django.utils.text import slugify
 
 
 class Category(models.Model):
@@ -13,9 +15,15 @@ class Category(models.Model):
         unique_together = ("name", "site")
         ordering = ['name']
 
-    def __str__(self):
-        return self.name
-
     def active_jobs(self):
         return self.job_set.filter(paid_at__isnull=False) \
                            .filter(expired_at__isnull=True)
+
+    def slug(self):
+        return slugify(self.name)
+
+    def get_absolute_url(self):
+        return reverse('categories_show_slug', args=(self.id, self.slug(),))
+
+    def __str__(self):
+        return self.name

--- a/job_board/models/company.py
+++ b/job_board/models/company.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.db import models
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
+from django.utils.text import slugify
 
 from job_board.models.country import Country
 
@@ -39,3 +40,6 @@ class Company(models.Model):
 
     def paid_jobs(self):
         return self.job_set.filter(paid_at__isnull=False)
+
+    def slug(self):
+        return slugify(self.name)

--- a/job_board/models/company.py
+++ b/job_board/models/company.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from django.db import models
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
+from django.core.urlresolvers import reverse
 from django.utils.text import slugify
 
 from job_board.models.country import Country
@@ -43,3 +44,6 @@ class Company(models.Model):
 
     def slug(self):
         return slugify(self.name)
+
+    def get_absolute_url(self):
+        return reverse('companies_show_slug', args=(self.id, self.slug(),))

--- a/job_board/models/job.py
+++ b/job_board/models/job.py
@@ -8,6 +8,7 @@ from django.contrib.sites.models import Site
 from django.template.loader import render_to_string
 from django.conf import settings
 from django.utils import timezone
+from django.utils.text import slugify
 
 from utils.misc import send_mail_with_helper
 
@@ -132,6 +133,9 @@ class Job(models.Model):
                    )
 
             api.update_status(post)
+
+    def slug(self):
+        return slugify('%s-%s' % (self.title, self.company.name))
 
     def __str__(self):
         return self.title

--- a/job_board/models/job.py
+++ b/job_board/models/job.py
@@ -5,6 +5,7 @@ import tweepy
 from django.db import models
 from django.contrib.auth.models import User
 from django.contrib.sites.models import Site
+from django.core.urlresolvers import reverse
 from django.template.loader import render_to_string
 from django.conf import settings
 from django.utils import timezone
@@ -136,6 +137,9 @@ class Job(models.Model):
 
     def slug(self):
         return slugify('%s-%s' % (self.title, self.company.name))
+
+    def get_absolute_url(self):
+        return reverse('jobs_show_slug', args=(self.id, self.slug(),))
 
     def __str__(self):
         return self.title

--- a/job_board/templates/job_board/categories_index.html
+++ b/job_board/templates/job_board/categories_index.html
@@ -12,7 +12,7 @@
     </thead>
     {% for category in categories %}
     <tr>
-      <td><a href="{% url 'categories_show' category.id %}">{{ category.name }}</a></td>
+      <td><a href="{% url 'categories_show_slug' category.id category.slug %}">{{ category.name }}</a></td>
       <td>{{ category.active_jobs.count }}</td>
     </tr>
     {% endfor %}

--- a/job_board/templates/job_board/companies_index.html
+++ b/job_board/templates/job_board/companies_index.html
@@ -15,7 +15,7 @@
   </thead>
   {% for company in companies %}
   <tr>
-    <td><a href="{% url 'companies_show' company.id %}">{{ company.name }}</a></td>
+    <td><a href="{% url 'companies_show_slug' company.id company.slug %}">{{ company.name }}</a></td>
     <td class="hidden-xs hidden-sm"><a href="{{ company.url }}">{{ company.url }}</a></td>
     <td class="hidden-xs hidden-sm"><a href="https://www.twitter.com/{{ company.twitter }}">{{ company.twitter }}</a></td>
     <td>{{ company.paid_jobs.count }}</td>

--- a/job_board/templates/job_board/jobs_index.html
+++ b/job_board/templates/job_board/jobs_index.html
@@ -17,7 +17,7 @@
   <tr>
     <td>{{ job.paid_at|date:'Y-m-d' }}</td>
     <td>
-      <a href="{% url 'jobs_show' job.id %}">{{ job.title }}</a><br>
+      <a href="{% url 'jobs_show_slug' job.id job.slug %}">{{ job.title }}</a><br>
       <small><strong>@&nbsp;{{ job.company.name }}</strong></small>
     </td>
     <td>{{ job.format_country }}</td>

--- a/job_board/templates/job_board/jobs_mine.html
+++ b/job_board/templates/job_board/jobs_mine.html
@@ -17,7 +17,7 @@
   <tr>
     <td>{{ job.created_at|date:'Y-m-d' }}</td>
     <td>
-      <a href="{% url 'jobs_show' job.id %}">{{ job.title }}</a><br>
+      <a href="{% url 'jobs_show_slug' job.id job.slug %}">{{ job.title }}</a><br>
       <small><strong>@&nbsp;{{ job.company.name }}</strong></small>
     </td>
     <td class="hidden-xs hidden-sm">{{ job.format_country }}</td>

--- a/job_board/templates/job_board/jobs_show.html
+++ b/job_board/templates/job_board/jobs_show.html
@@ -17,7 +17,9 @@
         <h4><mark>Twitter</mark></h4>
         <p><a href="https://twitter.com/{{ job.company.twitter }}">{{ job.company.twitter }}</a></p>
         {% endif %}
-        <a href="{% url 'companies_show' job.company.id %}" title="View all of company's jobs"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
+        <a href="{% url 'companies_show_slug' job.company.id job.company.slug %}" title="View all of company's jobs">
+          <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+        </a>
       </div>
     </div>
     {% if user.id == job.user.id or user.is_staff %}

--- a/job_board/tests/test_views.py
+++ b/job_board/tests/test_views.py
@@ -383,7 +383,8 @@ class JobViewAuthdTests(TestCase):
                        reverse('jobs_expire', args=(self.job1.id,))
                    )
         self.assertRedirects(
-            response, reverse('jobs_show', args=(self.job1.id,))
+            response,
+            reverse('jobs_show_slug', args=(self.job1.id, self.job1.slug()))
         )
 
     def test_edit_get_view(self):
@@ -403,10 +404,15 @@ class JobViewAuthdTests(TestCase):
             'city': 'Guelph'
         }
         response = self.client.post(
-                       reverse('jobs_edit', args=(self.job1.id,)), job
+                       reverse('jobs_edit', args=(self.job1.id,)),
+                       job
                    )
+        # Here we refresh the object otherwise it will show the old content
+        # from before the update
+        self.job1.refresh_from_db()
         self.assertRedirects(
-            response, reverse('jobs_show', args=(self.job1.id,))
+            response,
+            reverse('jobs_show_slug', args=(self.job1.id, self.job1.slug()))
         )
 
 
@@ -457,11 +463,15 @@ class JobViewAdminTests(TestCase):
                         reverse('jobs_activate', args=(self.job.id,))
                     )
         self.assertRedirects(
-            response1, reverse('jobs_show', args=(self.job.id,))
+            response1,
+            reverse('jobs_show_slug', args=(self.job.id, self.job.slug()))
         )
 
         response2 = self.client.get(
-                        reverse('jobs_show', args=(self.job.id,))
+                        reverse(
+                            'jobs_show_slug',
+                            args=(self.job.id, self.job.slug())
+                        )
                     )
         self.assertContains(
             response2,

--- a/job_board/tests/test_views.py
+++ b/job_board/tests/test_views.py
@@ -19,17 +19,25 @@ settings.SITE_ID = 1
 
 class CategoryViewTests(TestCase):
     def setUp(self):
-        category = Category(name='Software Development', site_id=1)
-        category.full_clean()
-        category.save()
+        self.category = Category(name='Software Development', site_id=1)
+        self.category.full_clean()
+        self.category.save()
 
     def test_index_view(self):
         response = self.client.get(reverse('categories_index'))
         self.assertEqual(response.status_code, 200)
 
     def test_show_view(self):
-        response = self.client.get(reverse('categories_show', args=(1,)))
+        response = self.client.get(self.category.get_absolute_url())
         self.assertEqual(response.status_code, 200)
+
+    def test_show_view_without_slug_redirects_to_slug(self):
+        response = self.client.get(
+                       reverse('categories_show', args=(self.category.id,))
+                   )
+        self.assertRedirects(
+            response, self.category.get_absolute_url(), status_code=301
+        )
 
 
 class CompanyUnauthdViewTests(TestCase):

--- a/job_board/tests/test_views.py
+++ b/job_board/tests/test_views.py
@@ -59,7 +59,9 @@ class CompanyUnauthdViewTests(TestCase):
         response = self.client.get(
                        reverse('companies_show', args=(self.company.id,))
                    )
-        self.assertRedirects(response, self.company.get_absolute_url(), status_code=301)
+        self.assertRedirects(
+            response, self.company.get_absolute_url(), status_code=301
+        )
 
     def test_show_view_does_not_display_edit_link(self):
         response = self.client.get(self.company.get_absolute_url())
@@ -181,7 +183,9 @@ class JobViewUnauthdTests(TestCase):
         response = self.client.get(
                        reverse('jobs_show', args=(self.job.id,))
                    )
-        self.assertRedirects(response, self.job.get_absolute_url(), status_code=301)
+        self.assertRedirects(
+            response, self.job.get_absolute_url(), status_code=301
+        )
 
     def test_show_view_does_not_show_job_admin(self):
         response = self.client.get(self.job.get_absolute_url())

--- a/job_board/tests/test_views.py
+++ b/job_board/tests/test_views.py
@@ -52,15 +52,17 @@ class CompanyUnauthdViewTests(TestCase):
         self.assertRedirects(response, '/login/?next=/companies/new')
 
     def test_show_view(self):
-        response = self.client.get(
-                       reverse('companies_show', args=(self.company.id,))
-                   )
+        response = self.client.get(self.company.get_absolute_url())
         self.assertEqual(response.status_code, 200)
 
-    def test_show_view_does_not_display_edit_link(self):
+    def test_show_view_without_slug_redirects_to_slug(self):
         response = self.client.get(
                        reverse('companies_show', args=(self.company.id,))
                    )
+        self.assertRedirects(response, self.company.get_absolute_url(), status_code=301)
+
+    def test_show_view_does_not_display_edit_link(self):
+        response = self.client.get(self.company.get_absolute_url())
         url = reverse('companies_edit', args=(self.company.id,))
         edit = '<a class="btn btn-primary btn-sm" ' \
                'href="%s">Edit Company</a>' % url
@@ -111,24 +113,18 @@ class CompanyAuthdViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_show_view(self):
-        response = self.client.get(
-                       reverse('companies_show', args=(self.company1.id,))
-                   )
+        response = self.client.get(self.company1.get_absolute_url())
         self.assertEqual(response.status_code, 200)
 
     def test_show_view_on_own_company_shows_edit_link(self):
-        response = self.client.get(
-                       reverse('companies_show', args=(self.company1.id,))
-                   )
+        response = self.client.get(self.company1.get_absolute_url())
         url = reverse('companies_edit', args=(self.company1.id,))
         edit = '<a class="btn btn-default btn-sm" ' \
                'href="%s">Edit Company</a>' % url
         self.assertContains(response, edit)
 
     def test_show_view_on_other_company_does_not_show_edit_link(self):
-        response = self.client.get(
-                       reverse('companies_show', args=(self.company2.id,))
-                   )
+        response = self.client.get(self.company2.get_absolute_url())
         url = reverse('companies_edit', args=(self.company2.id,))
         edit = '<a class="btn btn-primary btn-sm" ' \
                'href="%s">Edit Company</a>' % url
@@ -178,15 +174,21 @@ class JobViewUnauthdTests(TestCase):
         self.assertRedirects(response, '/login/?next=/jobs/mine/')
 
     def test_show_view(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job.id,)))
+        response = self.client.get(self.job.get_absolute_url())
         self.assertEqual(response.status_code, 200)
 
+    def test_show_view_without_slug_redirects_to_slug(self):
+        response = self.client.get(
+                       reverse('jobs_show', args=(self.job.id,))
+                   )
+        self.assertRedirects(response, self.job.get_absolute_url(), status_code=301)
+
     def test_show_view_does_not_show_job_admin(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job.id,)))
+        response = self.client.get(self.job.get_absolute_url())
         self.assertNotContains(response, 'Job Admin')
 
     def test_show_view_does_not_show_owner_email_address(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job.id,)))
+        response = self.client.get(self.job.get_absolute_url())
         self.assertNotContains(response, self.job.email)
 
     def test_activate_view(self):
@@ -315,59 +317,59 @@ class JobViewAuthdTests(TestCase):
         self.assertNotContains(response, self.job2.title)
 
     def test_show_view_on_own_paid_job(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job1.id,)))
+        response = self.client.get(self.job1.get_absolute_url())
         self.assertEqual(response.status_code, 200)
 
     def test_show_view_on_own_unpaid_job(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job4.id,)))
+        response = self.client.get(self.job4.get_absolute_url())
         self.assertEqual(response.status_code, 200)
 
     def test_show_view_on_own_unpaid_job_shows_unpaid_status(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job4.id,)))
+        response = self.client.get(self.job4.get_absolute_url())
         self.assertContains(
             response,
             '<span class="label label-warning">Unpaid</span>'
         )
 
     def test_show_view_on_other_users_paid_job(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job2.id,)))
+        response = self.client.get(self.job2.get_absolute_url())
         self.assertEqual(response.status_code, 200)
 
     def test_show_view_on_other_users_unpaid_job(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job3.id,)))
+        response = self.client.get(self.job3.get_absolute_url())
         self.assertEqual(response.status_code, 404)
 
     def test_show_view_on_own_job_shows_job_admin(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job1.id,)))
+        response = self.client.get(self.job1.get_absolute_url())
         self.assertContains(response, 'Job Admin')
 
     def test_show_view_on_own_job_does_not_show_posted_by(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job1.id,)))
+        response = self.client.get(self.job1.get_absolute_url())
         posted_by = '<h4><mark>Posted By</mark></h4>'
         self.assertNotContains(response, posted_by)
 
     def test_show_view_on_own_job_shows_expire_button(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job1.id,)))
+        response = self.client.get(self.job1.get_absolute_url())
         url = reverse('jobs_expire', args=(self.job1.id,))
         expire = '<a href="%s" class="btn btn-default">Expire</a>' % url
         self.assertContains(response, expire)
 
     def test_show_view_on_own_job_does_not_show_admin_activate_button(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job1.id,)))
+        response = self.client.get(self.job1.get_absolute_url())
         url = reverse('jobs_activate', args=(self.job1.id,))
         activate = '<a href="%s" class="btn btn-default">Activate</a>' % url
         self.assertNotContains(response, activate)
 
     def test_show_view_on_own_job_shows_email_address(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job1.id,)))
+        response = self.client.get(self.job1.get_absolute_url())
         self.assertContains(response, self.job1.email)
 
     def test_show_view_on_other_job_does_not_show_job_admin(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job2.id,)))
+        response = self.client.get(self.job2.get_absolute_url())
         self.assertNotContains(response, 'Job Admin')
 
     def test_show_view_on_other_job_does_not_show_email_address(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job2.id,)))
+        response = self.client.get(self.job2.get_absolute_url())
         self.assertNotContains(response, self.job2.email)
 
     def test_activate_view(self):
@@ -382,10 +384,7 @@ class JobViewAuthdTests(TestCase):
         response = self.client.get(
                        reverse('jobs_expire', args=(self.job1.id,))
                    )
-        self.assertRedirects(
-            response,
-            reverse('jobs_show_slug', args=(self.job1.id, self.job1.slug()))
-        )
+        self.assertRedirects(response, self.job1.get_absolute_url())
 
     def test_edit_get_view(self):
         response = self.client.get(reverse('jobs_edit', args=(self.job1.id,)))
@@ -410,10 +409,7 @@ class JobViewAuthdTests(TestCase):
         # Here we refresh the object otherwise it will show the old content
         # from before the update
         self.job1.refresh_from_db()
-        self.assertRedirects(
-            response,
-            reverse('jobs_show_slug', args=(self.job1.id, self.job1.slug()))
-        )
+        self.assertRedirects(response, self.job1.get_absolute_url())
 
 
 class JobViewAdminTests(TestCase):
@@ -462,17 +458,9 @@ class JobViewAdminTests(TestCase):
         response1 = self.client.get(
                         reverse('jobs_activate', args=(self.job.id,))
                     )
-        self.assertRedirects(
-            response1,
-            reverse('jobs_show_slug', args=(self.job.id, self.job.slug()))
-        )
+        self.assertRedirects(response1, self.job.get_absolute_url())
 
-        response2 = self.client.get(
-                        reverse(
-                            'jobs_show_slug',
-                            args=(self.job.id, self.job.slug())
-                        )
-                    )
+        response2 = self.client.get(self.job.get_absolute_url())
         self.assertContains(
             response2,
             '<span class="label label-success">Paid</span>'
@@ -485,7 +473,7 @@ class JobViewAdminTests(TestCase):
         )
 
     def test_show_view_shows_posted_by(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job.id,)))
+        response = self.client.get(self.job.get_absolute_url())
         header = '<h4><mark>Posted By</mark></h4>'
         posted_by = '<p>%s (UID: %s)</p>' % (self.other.username,
                                              self.other.id)
@@ -493,15 +481,15 @@ class JobViewAdminTests(TestCase):
         self.assertContains(response, posted_by)
 
     def test_show_view_on_other_users_unpaid_job(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job.id,)))
+        response = self.client.get(self.job.get_absolute_url())
         self.assertEqual(response.status_code, 200)
 
     def test_show_view_on_other_users_job_shows_email_address(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job.id,)))
+        response = self.client.get(self.job.get_absolute_url())
         self.assertContains(response, self.job.email)
 
     def test_show_view_on_other_users_job_shows_admin_activate_button(self):
-        response = self.client.get(reverse('jobs_show', args=(self.job.id,)))
+        response = self.client.get(self.job.get_absolute_url())
         url = reverse('jobs_activate', args=(self.job.id,))
         activate = '<a href="%s" class="btn btn-default">Activate</a>' % url
         self.assertContains(response, activate)

--- a/job_board/urls.py
+++ b/job_board/urls.py
@@ -13,6 +13,11 @@ urlpatterns = [
     url(r'^jobs/mine/$', jobs.jobs_mine, name='jobs_mine'),
     url(r'^jobs/(?P<job_id>[0-9]+)/$', jobs.jobs_show, name='jobs_show'),
     url(
+        r'^jobs/(?P<job_id>[0-9]+)-(?P<slug>[-\w\d]+)/$',
+        jobs.jobs_show,
+        name='jobs_show_slug'
+    ),
+    url(
         r'^jobs/(?P<job_id>[0-9]+)/activate$',
         jobs.jobs_activate,
         name='jobs_activate'
@@ -40,6 +45,11 @@ urlpatterns = [
         r'^companies/(?P<company_id>[0-9]+)/$',
         companies.companies_show,
         name='companies_show'
+    ),
+    url(
+        r'^companies/(?P<company_id>[0-9]+)-(?P<slug>[-\w\d]+)/$',
+        companies.companies_show,
+        name='companies_show_slug'
     ),
     url(
         r'^companies/(?P<company_id>[0-9]+)/edit$',

--- a/job_board/urls.py
+++ b/job_board/urls.py
@@ -38,6 +38,11 @@ urlpatterns = [
         categories.categories_show,
         name='categories_show'
     ),
+    url(
+        r'^categories/(?P<category_id>[0-9]+)-(?P<slug>[-\w\d]+)/$',
+        categories.categories_show,
+        name='categories_show_slug'
+    ),
     url(r'^charge$', misc.charge, name='charge'),
     url(r'^companies/$', companies.companies_index, name='companies_index'),
     url(r'^companies/new$', companies.companies_new, name='companies_new'),

--- a/job_board/views/categories.py
+++ b/job_board/views/categories.py
@@ -1,4 +1,5 @@
 from django.contrib.sites.shortcuts import get_current_site
+from django.http import HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404, render
 
 from job_board.models.category import Category
@@ -17,12 +18,15 @@ def categories_index(request):
     return render(request, 'job_board/categories_index.html', context)
 
 
-def categories_show(request, category_id):
+def categories_show(request, category_id, slug=None):
     category = get_object_or_404(
                    Category,
                    pk=category_id,
                    site_id=get_current_site(request).id
     )
+
+    if slug is None:
+        return HttpResponsePermanentRedirect(category.get_absolute_url())
 
     jobs = Job.objects.filter(site_id=get_current_site(request).id) \
                       .filter(category_id=category_id) \

--- a/job_board/views/companies.py
+++ b/job_board/views/companies.py
@@ -52,8 +52,12 @@ def companies_new(request):
                 'Your company has been successfully added'
             )
 
-            return HttpResponseRedirect(reverse('companies_show',
-                                                args=(company.id,)))
+            return HttpResponseRedirect(
+                       reverse(
+                           'companies_show_slug',
+                           args=(company.id, company.slug(),)
+                       )
+                   )
     else:
         # NOTE: site will be displayed in the HTML form as a hidden field, we
         #       need to find a way to set this in CompanyForm so validation
@@ -64,7 +68,7 @@ def companies_new(request):
     return render(request, 'job_board/companies_new.html', context)
 
 
-def companies_show(request, company_id):
+def companies_show(request, company_id, slug=None):
     company = get_object_or_404(
                   Company,
                   pk=company_id,
@@ -90,8 +94,12 @@ def companies_edit(request, company_id):
     title = 'Edit a Company'
 
     if request.user.id != company.user.id:
-        return HttpResponseRedirect(reverse('companies_show',
-                                            args=(company.id,)))
+        return HttpResponseRedirect(
+                   reverse(
+                       'companies_show_slug',
+                       args=(company.id, company.slug(),)
+                   )
+               )
 
     if request.method == 'POST':
         form = CompanyForm(request.POST, instance=company)
@@ -103,8 +111,12 @@ def companies_edit(request, company_id):
                 'Your company has been successfully updated'
             )
 
-            return HttpResponseRedirect(reverse('companies_show',
-                                                args=(company.id,)))
+            return HttpResponseRedirect(
+                       reverse(
+                           'companies_show_slug',
+                           args=(company.id, company.slug(),)
+                       )
+                   )
     else:
         form = CompanyForm(instance=company)
 

--- a/job_board/views/companies.py
+++ b/job_board/views/companies.py
@@ -3,7 +3,7 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404, render
 
 from job_board.forms import CompanyForm
@@ -52,12 +52,7 @@ def companies_new(request):
                 'Your company has been successfully added'
             )
 
-            return HttpResponseRedirect(
-                       reverse(
-                           'companies_show_slug',
-                           args=(company.id, company.slug(),)
-                       )
-                   )
+            return HttpResponseRedirect(company.get_absolute_url())
     else:
         # NOTE: site will be displayed in the HTML form as a hidden field, we
         #       need to find a way to set this in CompanyForm so validation
@@ -74,6 +69,10 @@ def companies_show(request, company_id, slug=None):
                   pk=company_id,
                   site_id=get_current_site(request).id
               )
+
+    if slug is None:
+        return HttpResponsePermanentRedirect(company.get_absolute_url())
+
     # We don't use get_list_or_404 here as we redirect to this view after
     # adding a new company and at that point it won't have any jobs assigned
     # to it.
@@ -94,12 +93,7 @@ def companies_edit(request, company_id):
     title = 'Edit a Company'
 
     if request.user.id != company.user.id:
-        return HttpResponseRedirect(
-                   reverse(
-                       'companies_show_slug',
-                       args=(company.id, company.slug(),)
-                   )
-               )
+        return HttpResponseRedirect(company.get_absolute_url())
 
     if request.method == 'POST':
         form = CompanyForm(request.POST, instance=company)
@@ -111,12 +105,7 @@ def companies_edit(request, company_id):
                 'Your company has been successfully updated'
             )
 
-            return HttpResponseRedirect(
-                       reverse(
-                           'companies_show_slug',
-                           args=(company.id, company.slug(),)
-                       )
-                   )
+            return HttpResponseRedirect(company.get_absolute_url())
     else:
         form = CompanyForm(instance=company)
 

--- a/job_board/views/companies.py
+++ b/job_board/views/companies.py
@@ -2,7 +2,6 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect, HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404, render
 

--- a/job_board/views/jobs.py
+++ b/job_board/views/jobs.py
@@ -80,7 +80,12 @@ def jobs_new(request):
 
             messages.success(request, 'Your job has been successfully added')
 
-            return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
+            return HttpResponseRedirect(
+                       reverse(
+                           'jobs_show_slug',
+                           args=(job.id, job.slug(),)
+                       )
+                   )
     else:
         if site.siteconfig.remote:
             form = JobRemoteForm()
@@ -103,7 +108,7 @@ def jobs_new(request):
     return render(request, 'job_board/jobs_new.html', context)
 
 
-def jobs_show(request, job_id):
+def jobs_show(request, job_id, slug=None):
     job = get_object_or_404(
               Job, pk=job_id, site_id=get_current_site(request).id
           )
@@ -146,7 +151,12 @@ def jobs_edit(request, job_id):
     title = 'Edit a Job'
 
     if request.user.id != job.user.id:
-        return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
+        return HttpResponseRedirect(
+                   reverse(
+                       'jobs_show_slug',
+                       args=(job.id, job.slug(),)
+                   )
+               )
 
     if request.method == 'POST':
         if site.siteconfig.remote:
@@ -165,7 +175,12 @@ def jobs_edit(request, job_id):
 
             messages.success(request, 'Your job has been successfully updated')
 
-            return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
+            return HttpResponseRedirect(
+                       reverse(
+                           'jobs_show_slug',
+                           args=(job.id, job.slug(),)
+                       )
+                   )
     else:
         if site.siteconfig.remote:
             form = JobRemoteForm(instance=job)
@@ -190,7 +205,12 @@ def jobs_activate(request, job_id):
               Job, pk=job_id, site_id=get_current_site(request).id
           )
     job.activate()
-    return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
+    return HttpResponseRedirect(
+               reverse(
+                   'jobs_show_slug',
+                   args=(job.id, job.slug(),)
+               )
+           )
 
 
 @login_required(login_url='/login/')
@@ -200,7 +220,17 @@ def jobs_expire(request, job_id):
           )
 
     if request.user.id != job.user.id:
-        return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
+        return HttpResponseRedirect(
+                   reverse(
+                       'jobs_show_slug',
+                       args=(job.id, job.slug(),)
+                   )
+               )
 
     job.expire()
-    return HttpResponseRedirect(reverse('jobs_show', args=(job.id,)))
+    return HttpResponseRedirect(
+               reverse(
+                   'jobs_show_slug',
+                   args=(job.id, job.slug(),)
+               )
+           )

--- a/job_board/views/jobs.py
+++ b/job_board/views/jobs.py
@@ -4,7 +4,8 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.contrib import messages
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from django.core.urlresolvers import reverse
-from django.http import Http404, HttpResponseRedirect
+from django.http import (Http404, HttpResponseRedirect,
+                         HttpResponsePermanentRedirect)
 from django.shortcuts import get_object_or_404, render
 from django.template.loader import render_to_string
 
@@ -80,12 +81,7 @@ def jobs_new(request):
 
             messages.success(request, 'Your job has been successfully added')
 
-            return HttpResponseRedirect(
-                       reverse(
-                           'jobs_show_slug',
-                           args=(job.id, job.slug(),)
-                       )
-                   )
+            return HttpResponseRedirect(job.get_absolute_url())
     else:
         if site.siteconfig.remote:
             form = JobRemoteForm()
@@ -112,6 +108,10 @@ def jobs_show(request, job_id, slug=None):
     job = get_object_or_404(
               Job, pk=job_id, site_id=get_current_site(request).id
           )
+
+    if slug is None:
+        return HttpResponsePermanentRedirect(job.get_absolute_url())
+
     site = get_current_site(request)
     # If the browsing user does not own the job, and the job has yet to be paid
     # for, then 404
@@ -151,12 +151,7 @@ def jobs_edit(request, job_id):
     title = 'Edit a Job'
 
     if request.user.id != job.user.id:
-        return HttpResponseRedirect(
-                   reverse(
-                       'jobs_show_slug',
-                       args=(job.id, job.slug(),)
-                   )
-               )
+        return HttpResponseRedirect(job.get_absolute_url())
 
     if request.method == 'POST':
         if site.siteconfig.remote:
@@ -175,12 +170,7 @@ def jobs_edit(request, job_id):
 
             messages.success(request, 'Your job has been successfully updated')
 
-            return HttpResponseRedirect(
-                       reverse(
-                           'jobs_show_slug',
-                           args=(job.id, job.slug(),)
-                       )
-                   )
+            return HttpResponseRedirect(job.get_absolute_url())
     else:
         if site.siteconfig.remote:
             form = JobRemoteForm(instance=job)
@@ -205,12 +195,7 @@ def jobs_activate(request, job_id):
               Job, pk=job_id, site_id=get_current_site(request).id
           )
     job.activate()
-    return HttpResponseRedirect(
-               reverse(
-                   'jobs_show_slug',
-                   args=(job.id, job.slug(),)
-               )
-           )
+    return HttpResponseRedirect(job.get_absolute_url())
 
 
 @login_required(login_url='/login/')
@@ -220,17 +205,7 @@ def jobs_expire(request, job_id):
           )
 
     if request.user.id != job.user.id:
-        return HttpResponseRedirect(
-                   reverse(
-                       'jobs_show_slug',
-                       args=(job.id, job.slug(),)
-                   )
-               )
+        return HttpResponseRedirect(job.get_absolute_url())
 
     job.expire()
-    return HttpResponseRedirect(
-               reverse(
-                   'jobs_show_slug',
-                   args=(job.id, job.slug(),)
-               )
-           )
+    return HttpResponseRedirect(job.get_absolute_url())

--- a/job_board/views/jobs.py
+++ b/job_board/views/jobs.py
@@ -3,7 +3,6 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.contrib import messages
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.core.urlresolvers import reverse
 from django.http import (Http404, HttpResponseRedirect,
                          HttpResponsePermanentRedirect)
 from django.shortcuts import get_object_or_404, render


### PR DESCRIPTION
This commit adds slugs to the following views:

* jobs_show
* companies_show
* categories_show

The old non-slug URLs are still present, and if someone hits a resource
on any of them it will redirect 301 to the slug.

We also override get_absolute_url() in the job, company, and category
models which means we do not need to do a reverse lookup on ID and
slug.  This is a fair bit less code and generally looks cleaner.

All applicable tests now use get_absolute_url() and a test for each
view has been added to ensure the redirect 301 happens correctly.