### PR TITLE
Initialise subscribe form

### DIFF
--- a/job_board/views/categories.py
+++ b/job_board/views/categories.py
@@ -1,6 +1,7 @@
 from django.contrib.sites.shortcuts import get_current_site
 from django.shortcuts import get_object_or_404, render
 
+from job_board.forms import SubscribeForm
 from job_board.models.category import Category
 from job_board.models.job import Job
 
@@ -29,5 +30,6 @@ def categories_show(request, category_id):
                       .filter(paid_at__isnull=False) \
                       .filter(expired_at__isnull=True) \
                       .order_by('-paid_at')
-    context = {'jobs': jobs, 'title': '%s Jobs' % category.name}
+    form = SubscribeForm()
+    context = {'form': form, 'jobs': jobs, 'title': '%s Jobs' % category.name}
     return render(request, 'job_board/jobs_index.html', context)


### PR DESCRIPTION
Currently we do not initialise the subscriber form in the
categories_show view.  This commit updates that specific view so that
the form object is passed to the template.