### PR TITLE
Add company on job post page

### DIFF
--- a/job_board/templates/job_board/_base.html
+++ b/job_board/templates/job_board/_base.html
@@ -34,9 +34,6 @@
             <li role="presentation"><a href="{% url 'categories_index' %}">Categories</a></li>
             <li role="presentation"><a href="{% url 'companies_index' %}">Companies</a></li>
             <li role="presentation"><a href="{% url 'contact' %}">Contact Us</a></li>
-            {% if user.is_authenticated %}
-            <li role="presentation"><a href="{% url 'companies_new' %}">Add Company</a></li>
-            {% endif %}
             <li role="presentation"><a href="{% url 'jobs_new' %}">Post Job</a></li>
           </ul>
           <ul class="nav navbar-nav navbar-right">

--- a/job_board/templates/job_board/_errors.html
+++ b/job_board/templates/job_board/_errors.html
@@ -1,14 +1,22 @@
-{% if form.non_field_errors %}
+{% if form.errors %}
 <div class="panel panel-danger">
   <div class="panel-heading">
     <h3 class="panel-title">{{ form.errors|length }} error(s) prevented your resource from being saved</h3>
   </div>
   <div class="panel-body">
+    {% if form.non_field_errors %}
     <ul>
     {% for error in form.non_field_errors %}
       <li>{{ error }}</li>
     {% endfor %}
     </ul>
+    {% endif %}
+
+    {% for field in form %}
+    {% if field.errors %}
+    {{ field.errors }}
+    {% endif %}
+    {% endfor %}
   </div>
 </div>
 {% endif %}

--- a/job_board/templates/job_board/jobs_new.html
+++ b/job_board/templates/job_board/jobs_new.html
@@ -2,14 +2,47 @@
 
 {% block content %}
 {% include "job_board/_header.html" %}
-{% include "job_board/_errors.html" %}
-
 <div class="row">
   <div class="col-md-4">
     {% include "job_board/_markdown.html" %}
   </div>
   <div class="col-md-8">
-    <form action="{% url 'jobs_new' %}" method="post">
+    <div id="error-messages">
+    {% include "job_board/_errors.html" %}
+    </div>
+    <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+        <div class="panel-heading" role="tab" id="headingTwo">
+          <a class="collapsed" role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+            Add a new company
+          </a>
+        </div>
+        <div id="collapseTwo" class="panel-collapse collapse" role="tabpanel" aria-labelledby="headingTwo">
+          <div class="panel-body">
+            <form action="{% url 'companies_new' %}" method="post" id="add-company">
+              {% csrf_token %}
+              {% for field in company_form %}
+              {% if field.is_hidden %}
+              {{ field }}
+              {% else %}
+              <div class="form-group {% if field.errors %}has-error{% endif %}">
+                {# We generate the label manually here as it's not clear how to set class the label_tag #}
+                <label for="{{ field.id_for_label }}" class="control-label">{{ field.label }}</label>
+                {{ field }}
+                <div class="help-block">
+                  {% if field.help_text %}<p>{{ field.help_text|safe }}</p>{% endif %}
+                  {{ field.errors }}
+                </div>
+              </div>
+              {% endif %}
+              {% endfor %}
+              <input type="submit" class="btn btn-success" value="Add Company" />
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+    <form action="" method="post">
       {% csrf_token %}
       {% for field in form %}
       {% if field.is_hidden %}
@@ -26,7 +59,7 @@
       </div>
       {% endif %}
       {% endfor %}
-      <input type="submit" class="btn btn-success" value="Post" />
+      <input type="submit" class="btn btn-success" value="Post Job" />
     </form>
   </div>
 </div>
@@ -35,6 +68,28 @@
 {% block javascript %}
 <script>
   $( document ).ready(function() {
+    $('#add-company').on('submit', function(e){
+        // http://stackoverflow.com/questions/20195483/jquery-ajax-form-submits-twice
+        e.preventDefault();
+        $.ajax({
+            url : "{% url 'companies_new' %}", // the endpoint
+            type : "POST", // http method
+            data : $(this).serialize(), // data sent with the post request
+
+            // handle a successful response
+            success : function(json) {
+                $('#accordion').hide();
+                $('#error-messages').hide();
+                $('#id_company').append('<option value="' + json.id + '">' + json.name + '</option>"').val(json.id);
+            },
+
+            // handle a non-successful response
+            error : function(xhr,errmsg,err) {
+                $(xhr.responseText).appendTo("#error-messages");
+            }
+        });
+    });
+
     if ($( "#id_remote" ).is( ":checked" )) {
       $( "#togglecity" ).hide();
       $( "#togglestate" ).hide();

--- a/job_board/views/companies.py
+++ b/job_board/views/companies.py
@@ -2,7 +2,8 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
-from django.http import HttpResponseRedirect, HttpResponsePermanentRedirect
+from django.http import (HttpResponseRedirect, HttpResponsePermanentRedirect,
+                         JsonResponse)
 from django.shortcuts import get_object_or_404, render
 
 from job_board.forms import CompanyForm
@@ -46,12 +47,23 @@ def companies_new(request):
             company.user_id = request.user.id
             company.save()
 
-            messages.success(
-                request,
-                'Your company has been successfully added'
-            )
+            if request.is_ajax():
+                return JsonResponse({'id': company.id, 'name': company.name})
+            else:
+                messages.success(
+                    request,
+                    'Your company has been successfully added'
+                )
+                return HttpResponseRedirect(company.get_absolute_url())
 
-            return HttpResponseRedirect(company.get_absolute_url())
+        else:
+            if request.is_ajax():
+                return render(
+                    request,
+                    'job_board/_errors.html',
+                    {'form': form},
+                    status=400
+                )
     else:
         # NOTE: site will be displayed in the HTML form as a hidden field, we
         #       need to find a way to set this in CompanyForm so validation

--- a/job_board/views/jobs.py
+++ b/job_board/views/jobs.py
@@ -10,7 +10,7 @@ from django.template.loader import render_to_string
 
 from utils.misc import send_mail_with_helper
 
-from job_board.forms import JobForm, JobRemoteForm, SubscribeForm
+from job_board.forms import CompanyForm, JobForm, JobRemoteForm, SubscribeForm
 from job_board.models.category import Category
 from job_board.models.company import Company
 from job_board.models.job import Job
@@ -60,6 +60,8 @@ def jobs_new(request):
         else:
             form = JobForm(request.POST)
 
+        company_form = CompanyForm(initial={'site': site})
+
         if form.is_valid():
             job = form.save(commit=False)
             if site.siteconfig.remote:
@@ -87,6 +89,8 @@ def jobs_new(request):
         else:
             form = JobForm()
 
+        company_form = CompanyForm(initial={'site': site})
+
     # NOTE: By default, the company and category dropdowns will contain all
     #       instances across all sites, and the following limits this to
     #       the site in question.
@@ -98,6 +102,7 @@ def jobs_new(request):
                                        )
 
     context = {'form': form,
+               'company_form': company_form,
                'title': title,
                'protocol': site.siteconfig.protocol}
     return render(request, 'job_board/jobs_new.html', context)


### PR DESCRIPTION
This commit removes the 'Add Company' link in the header and adds a
from to add a company in the jobs_new.html page.  This form uses an
ajax request so that we can add a company without page fresh, and once
the job is added the company is automatically selected in the dropdown
and the company add form disappears.

Note that companies_add view in companies.py should still handle adding
a company separately, so that the old template will still work.
Additionally, _errors.html template is updated to display all errors,
not just non_field_errors.  This is because companies_add view renders
this template, so in its previous form all non non_field_errors would
be lost.

Lastly, I don't do JavaScript, so apologies if any of this jQuery
committed here is an abomination.

Closes #72