### PR TITLE
Category RSS feeds

### DIFF
--- a/job_board/templates/job_board/_base.html
+++ b/job_board/templates/job_board/_base.html
@@ -8,6 +8,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{{ title|default:current_site.name}}</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous" />
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="{% static 'job_board/style.css' %}" />
   </head>
   <body>

--- a/job_board/templates/job_board/categories_index.html
+++ b/job_board/templates/job_board/categories_index.html
@@ -8,12 +8,14 @@
       <tr>
         <th>Name</th>
         <th>Jobs</th>
+        <th>&nbsp;</th>
       </tr>
     </thead>
     {% for category in categories %}
     <tr>
       <td><a href="{% url 'categories_show_slug' category.id category.slug %}">{{ category.name }}</a></td>
       <td>{{ category.active_jobs.count }}</td>
+      <td><a href="{% url 'categories_feed' category.id category.slug %}"><i class="fa fa-rss" aria-hidden="true" /></a></td>
     </tr>
     {% endfor %}
   </table>

--- a/job_board/urls.py
+++ b/job_board/urls.py
@@ -4,6 +4,7 @@ import job_board.views.jobs as jobs
 import job_board.views.categories as categories
 import job_board.views.companies as companies
 import job_board.views.misc as misc
+import job_board.views.feeds as feeds
 
 urlpatterns = [
     url(r'^$', jobs.jobs_index, name='jobs_index'),
@@ -42,6 +43,11 @@ urlpatterns = [
         r'^categories/(?P<category_id>[0-9]+)-(?P<slug>[-\w\d]+)/$',
         categories.categories_show,
         name='categories_show_slug'
+    ),
+    url(
+        r'^categories/(?P<category_id>[0-9]+)-(?P<slug>[-\w\d]+)/rss$',
+        feeds.CategoryFeed(),
+        name='categories_feed'
     ),
     url(r'^charge_card$', misc.charge_card, name='charge_card'),
     url(r'^charge_token$', misc.charge_token, name='charge_token'),

--- a/job_board/views/feeds.py
+++ b/job_board/views/feeds.py
@@ -1,0 +1,32 @@
+from django.contrib.sites.shortcuts import get_current_site
+from django.contrib.syndication.views import Feed
+from job_board.models.category import Category
+from job_board.models.job import Job
+
+
+class CategoryFeed(Feed):
+    def title(self, obj):
+        return '%s - %s Jobs Feed' % (obj.site.name, obj.name)
+
+    def link(self, obj):
+        return obj.get_absolute_url()
+
+    def description(self, obj):
+        return 'The latest %s jobs on %s' % (obj.name, obj.site.name)
+
+    def get_object(self, request, category_id, slug=None):
+        return Category.objects.get(
+                   pk=category_id, site_id=get_current_site(request).id
+               )
+
+    def items(self, obj):
+        return Job.objects.filter(category_id=obj) \
+                          .filter(paid_at__isnull=False) \
+                          .filter(expired_at__isnull=True) \
+                          .order_by('-paid_at')[:30]
+
+    def item_title(self, item):
+        return '%s @ %s' % (item.title, item.company.name)
+
+    def item_description(self, item):
+        return item.description


### PR DESCRIPTION
This commit adds in an initial RSS feed for job categories.  At
present, up to 30 max will be returned in the feed.  This may need to
be made customisable at a later date.

We also add font awesome fonts via CDN.  We may want to look at pulling
these into source control in the near future.

Closes #156