### PR TITLE
HTMLize feed description

### DIFF
--- a/job_board/templates/job_board/_base.html
+++ b/job_board/templates/job_board/_base.html
@@ -6,15 +6,16 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% spaceless %}
     {% if meta_desc %}
     <meta name="description" content="{{ meta_desc }}">
     {% endif %}
-    {% endspaceless %}
     <title>{{ title|default:current_site.name}}</title>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous" />
     <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet" integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous">
     <link rel="stylesheet" type="text/css" href="{% static 'job_board/style.css' %}" />
+    {% if link_rss %}
+    <link rel="alternate" type="application/rss+xml" href="{{ link_rss }}" />
+    {% endif %}
   </head>
   <body>
     {% if current_site.siteconfig.google_analytics %}

--- a/job_board/templates/job_board/categories_index.html
+++ b/job_board/templates/job_board/categories_index.html
@@ -15,7 +15,7 @@
     <tr>
       <td><a href="{% url 'categories_show_slug' category.id category.slug %}">{{ category.name }}</a></td>
       <td>{{ category.active_jobs.count }}</td>
-      <td><a href="{% url 'categories_feed' category.id category.slug %}"><i class="fa fa-rss" aria-hidden="true" /></a></td>
+      <td><a rel="alternate" type="application/rss+xml" href="{% url 'categories_feed' category.id category.slug %}"><i class="fa fa-rss" aria-hidden="true" /></a></td>
     </tr>
     {% endfor %}
   </table>

--- a/job_board/views/categories.py
+++ b/job_board/views/categories.py
@@ -1,6 +1,7 @@
 from django.contrib.sites.shortcuts import get_current_site
 from django.http import HttpResponsePermanentRedirect
 from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
 
 from job_board.forms import SubscribeForm
 from job_board.models.category import Category
@@ -39,8 +40,10 @@ def categories_show(request, category_id, slug=None):
                       .order_by('-paid_at')
     form = SubscribeForm()
     meta_desc = 'Browse a list of all active %s jobs' % category.name
+    feed_url = reverse('categories_feed', args=(category.id, category.slug(),))
     title = '%s Jobs' % category.name
     context = {'meta_desc': meta_desc,
+               'link_rss': feed_url,
                'title': title,
                'form': form,
                'jobs': jobs}

--- a/job_board/views/feeds.py
+++ b/job_board/views/feeds.py
@@ -3,6 +3,8 @@ from django.contrib.syndication.views import Feed
 from job_board.models.category import Category
 from job_board.models.job import Job
 
+import markdown
+
 
 class CategoryFeed(Feed):
     def title(self, obj):
@@ -29,4 +31,5 @@ class CategoryFeed(Feed):
         return '%s @ %s' % (item.title, item.company.name)
 
     def item_description(self, item):
-        return item.description
+        md = markdown.Markdown(safe_mode='remove')
+        return md.convert(item.description)


### PR DESCRIPTION
Currently, the feed description is output as markdown.  This commit
converts it to HTML so that RSS readers render the description as HTML.

Additionally, we update the base template to display a link to an RSS
link when a URL is passed in from the view.  At present we only do this
from the categories_show view.