### PR TITLE
Add display_lists command

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,17 @@ of all jobs posted in the last 7 days:
 Again, cron the above to run once a week so that these campaigns are built and
 sent automatically.
 
+If you're unsure what the `mailchimp_list_id` is for the list in question,
+populate `mailchimp_username` and `mailchimp_api_key` for the site and then run
+the following command to display all lists on this site's MailChimp account:
+
+```
+(.venv) $ python manage.py display_lists <site_domain>
+```
+
+The value under the ID column for the associated list is what should get
+assigned to `mailchimp_list_id`.
+
 ## Support
 
 Found a bug or need help with installation?  Please feel free to create an [issue](https://github.com/wfhio/tramcar/issues/new) or drop into [Slack](http://tramcar.now.sh/) and we will assist as soon as possible.

--- a/job_board/management/commands/display_lists.py
+++ b/job_board/management/commands/display_lists.py
@@ -1,0 +1,56 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.sites.models import Site
+from django.core.exceptions import ObjectDoesNotExist
+
+from mailchimp3 import MailChimp
+
+
+class Command(BaseCommand):
+    help = 'Display all MailChimp lists'
+
+    def add_arguments(self, parser):
+            parser.add_argument('site_domain', nargs=1, type=str)
+
+    def handle(self, *args, **options):
+        site_domain = options['site_domain'][0]
+
+        try:
+            site = Site.objects.get(domain=site_domain)
+        except ObjectDoesNotExist:
+            raise CommandError(
+                    'Site with domain name %s does not exist' % site_domain
+                  )
+        else:
+            if (site.siteconfig.mailchimp_username and
+                    site.siteconfig.mailchimp_api_key):
+
+                client = MailChimp(
+                             site.siteconfig.mailchimp_username,
+                             site.siteconfig.mailchimp_api_key
+                         )
+
+                try:
+                    lists = client.lists.all()
+                except:
+                    raise CommandError(
+                            'There was a problem connecting to the MailChimp '
+                            'API, check your credentials and try again'
+                          )
+
+                if len(lists['lists']) > 0:
+                    msg = "The following MailChimp lists exist:\n"
+                    msg += "ID\t\tName\n"
+
+                    for list in lists['lists']:
+                        msg += "%s\t%s\n" % (list['id'], list['name'])
+                    self.stdout.write(self.style.SUCCESS(msg))
+                else:
+                    msg = "No lists were found for site with domain " \
+                          "name %s" % site_domain
+                    self.stdout.write(self.style.NOTICE(msg))
+            else:
+                raise CommandError(
+                          'A MailChimp username and or api_key have '
+                          'not been configured on the site with domain '
+                          'name %s' % site_domain
+                      )


### PR DESCRIPTION
This adds a display_lists command which is helpful when configuring
Tramcar to send a weekly MailChimp mailshot for a given site.  The
output of the command includes a list of MailChimp list IDs and list
names, which can then be used to populate `mailchimp_list_id` for that
site.

Obviously `mailchimp_username` and `mailchimp_api_key` needs to have
been set in the admin panel for the site in question.

Example:

```
(.venv) $ python manage.py display_lists <site_domain>
```