### PR TITLE
Bump Django to 1.11.11

### DIFF
--- a/job_board/management/commands/display_lists.py
+++ b/job_board/management/commands/display_lists.py
@@ -31,7 +31,7 @@ class Command(BaseCommand):
 
                 try:
                     lists = client.lists.all()
-                except:
+                except Exception:
                     raise CommandError(
                             'There was a problem connecting to the MailChimp '
                             'API, check your credentials and try again'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==1.11.1
+Django==1.11.11
 Markdown==2.6.6
 mailchimp3==2.0.3
 stripe==1.42.0


### PR DESCRIPTION
Note that we also have to fix a failing flake8 test (E722 do not use
bare except) due to our use of bare except.