### PR TITLE
Update requirements to support Python 3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-Django==1.11.15
+Django==1.11.17
 Markdown==2.6.6
 mailchimp3==2.0.3
 stripe==1.42.0
-tweepy==3.5.0
+tweepy==3.7.0
 wheel==0.24.0


### PR DESCRIPTION
Django and tweepy fail with the following errors when installing tramcar in a Python 3.7 environment:

Django:

```
  File "/usr/home/user/virtualenvs/tramcar/lib/python3.7/site-packages/django/contrib/admin/widgets.py", line 152
    '%s=%s' % (k, v) for k, v in params.items(),
    ^
SyntaxError: Generator expression must be parenthesized
```

tweepy:

```
  File "/usr/home/user/virtualenvs/tramcar/lib/python3.7/site-packages/tweepy/streaming.py", line 355
    def _start(self, async):
                         ^
SyntaxError: invalid syntax
```

These issues have been fixed upstream [1][2], update requirements.txt to use those versions accordingly

[1] https://code.djangoproject.com/ticket/29565
[2] https://github.com/tweepy/tweepy/issues/1017