### PR TITLE
Fix failing E117 error

### DIFF
--- a/job_board/management/commands/display_lists.py
+++ b/job_board/management/commands/display_lists.py
@@ -9,7 +9,7 @@ class Command(BaseCommand):
     help = 'Display all MailChimp lists'
 
     def add_arguments(self, parser):
-            parser.add_argument('site_domain', nargs=1, type=str)
+        parser.add_argument('site_domain', nargs=1, type=str)
 
     def handle(self, *args, **options):
         site_domain = options['site_domain'][0]


### PR DESCRIPTION
Flake8 is currently failing in CI due to an E117 error.