### PR TITLE
Update travis.yml to test Python 3.6-3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "3.5"
+  - "3.6"
+  - "3.7"
+  - "3.8"
 notifications:
   email: false
 # command to install dependencies


### PR DESCRIPTION
Django 3.x only supports Python 3.6, 3.7, 3.8 (#176)

Update travis.yml to begin testing these versions to identify issues and incompatibilities early