### PR TITLE
Bump bleach

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==2.2.11
 Markdown==3.2.1
-bleach==3.1.1
+bleach==3.1.2
 bleach-whitelist==0.0.10
 mailchimp3==2.0.3
 stripe==1.42.0


### PR DESCRIPTION
This bump is to address CVE-2020-6816 [1].

[1] https://github.com/advisories/GHSA-m6xf-fq7q-8743